### PR TITLE
fix: cleanup cargo subtype display code

### DIFF
--- a/build.py
+++ b/build.py
@@ -9,6 +9,7 @@ from constants import constants
 
 inputs = [
     "src/german_industries.pnml",
+    "src/cargo_subtype_display.pnml",
     "src/default_graphics.pnml",
     "src/electricity.pnml",
     "src/location_checks.pnml",

--- a/lang/german.lng
+++ b/lang/german.lng
@@ -1,4 +1,5 @@
 ##grflangid 0x02
+##plural 0
 # This is the German language file
 
 # GRF name und Beschreibung
@@ -86,4 +87,4 @@ STR_CARGO_SUBTYPE_DISPLAY_CARGO_BOOSTS_PRODUCTION :{WHITE}({CARGO_SHORT} vorrät
 # Fehlertexte
 STR_ERR_OPENTTD_VERSION:{ORANGE}E00: {TITLE} benötigt OpenTTD 14.0 oder neuer
 STR_ERR_LOCATION_NOT_ABOVE_SNOWLINE: muss unterhalb der Schneegrenze platziert werden
-STR_ERRO_LOCATION_NOT_ON_STEEP_SLOPE: kann nicht auf steilen Hängen platziert werden
+STR_ERR_LOCATION_NOT_ON_STEEP_SLOPE: kann nicht auf steilen Hängen platziert werden

--- a/src/cargo_subtype_display.pnml
+++ b/src/cargo_subtype_display.pnml
@@ -1,0 +1,93 @@
+switch(FEAT_INDUSTRIES, SELF, switch_cargo_subtype_display_info_coal, 
+	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("COAL") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
+	 getbits(extra_callback_info2, 16, 8)]) {
+	COAL: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
+	return 0x3800 + string(STR_EMPTY);
+}
+
+switch(FEAT_INDUSTRIES, SELF, switch_cargo_subtype_display_info_fish, 
+	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("FISH") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
+	 getbits(extra_callback_info2, 16, 8)]) {
+	//FISH: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
+	//return 0x3800 + string(STR_EMPTY);
+	return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
+}
+
+switch(FEAT_INDUSTRIES, SELF, switch_cargo_subtype_display_info_grai, 
+	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("GRAI") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
+	 getbits(extra_callback_info2, 16, 8)]) {
+	GRAI: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
+	return 0x3800 + string(STR_EMPTY);
+}
+
+switch(FEAT_INDUSTRIES, SELF, switch_cargo_subtype_display_info_iore, 
+	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("IORE") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
+	 getbits(extra_callback_info2, 16, 8)]) {
+	IORE: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
+	return 0x3800 + string(STR_EMPTY);
+}
+
+switch(FEAT_INDUSTRIES, SELF, switch_cargo_subtype_display_info_lvst, 
+	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("LVST") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
+	 getbits(extra_callback_info2, 16, 8)]) {
+	LVST: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
+	return 0x3800 + string(STR_EMPTY);
+}
+
+switch(FEAT_INDUSTRIES, SELF, switch_cargo_subtype_display_info_oil, 
+	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("OIL_") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
+	 getbits(extra_callback_info2, 16, 8)]) {
+	OIL_: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
+	return 0x3800 + string(STR_EMPTY);
+}
+
+switch(FEAT_INDUSTRIES, SELF, switch_cargo_subtype_display_info_plas, 
+	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("PLAS") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
+	 getbits(extra_callback_info2, 16, 8)]) {
+	PLAS: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
+	return 0x3800 + string(STR_EMPTY);
+}
+
+switch(FEAT_INDUSTRIES, SELF, switch_cargo_subtype_display_info_stel, 
+	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("STEL") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
+	 getbits(extra_callback_info2, 16, 8)]) {
+	STEL: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
+	return 0x3800 + string(STR_EMPTY);
+}
+
+switch(FEAT_INDUSTRIES, SELF, switch_cargo_subtype_display_info_wdpr, 
+	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("WDPR") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
+	 getbits(extra_callback_info2, 16, 8)]) {
+	WDPR: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
+	return 0x3800 + string(STR_EMPTY);
+}
+
+switch(FEAT_INDUSTRIES, SELF, switch_cargo_subtype_display_info_wood, 
+	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("WOOD") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
+	 getbits(extra_callback_info2, 16, 8)]) {
+	WOOD: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
+	return 0x3800 + string(STR_EMPTY);
+}
+
+switch(FEAT_INDUSTRIES, SELF, switch_cargo_subtype_display_info, 
+	getbits(extra_callback_info2, 16, 8)) {
+	COAL: switch_cargo_subtype_display_info_coal;
+	FISH: switch_cargo_subtype_display_info_fish;
+	GRAI: switch_cargo_subtype_display_info_grai;
+	IORE: switch_cargo_subtype_display_info_iore;
+	LVST: switch_cargo_subtype_display_info_lvst;
+	OIL_: switch_cargo_subtype_display_info_oil;
+	PLAS: switch_cargo_subtype_display_info_plas;	
+	STEL: switch_cargo_subtype_display_info_stel;
+	WDPR: switch_cargo_subtype_display_info_wdpr;
+	WOOD: switch_cargo_subtype_display_info_wood;
+	return 0x3800 + string(STR_EMPTY);
+}
+
+// getbits(extra_callback_info2, 8, 8) == 1 -> industry window, 0 -> industry buy/prospect window, 2 -> industry directory
+switch(FEAT_INDUSTRIES, SELF, switch_cargo_subtype, 
+	 getbits(extra_callback_info2, 8, 8)) {
+	0: return CB_RESULT_IND_NO_TEXT_NO_AMOUNT;
+	1: switch_cargo_subtype_display_info;
+	return 0x3800 + string(STR_EMPTY);
+}

--- a/src/industries/food_processor.pnml
+++ b/src/industries/food_processor.pnml
@@ -473,46 +473,6 @@ switch(FEAT_INDUSTRIES, SELF, food_processor_switch_produce,
 	food_processor_switch_produce_fish;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// cargo subtexts to show how much incoming cargo is waiting
-////////////////////////////////////////////////////////////////////////////////
-switch(FEAT_INDUSTRIES, SELF, food_processor_switch_cargo_subtype_display_info_lvst, 
-	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("LVST") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
-	 getbits(extra_callback_info2, 16, 8)]) {
-	LVST: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
-	return 0x3800 + string(STR_EMPTY);
-}
-
-switch(FEAT_INDUSTRIES, SELF, food_processor_switch_cargo_subtype_display_info_grai, 
-	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("GRAI") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
-	 getbits(extra_callback_info2, 16, 8)]) {
-	GRAI: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
-	return 0x3800 + string(STR_EMPTY);
-}
-
-switch(FEAT_INDUSTRIES, SELF, food_processor_switch_cargo_subtype_display_info_fish, 
-	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("FISH") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
-	 getbits(extra_callback_info2, 16, 8)]) {
-	FISH: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
-	return 0x3800 + string(STR_EMPTY);
-}
-
-switch(FEAT_INDUSTRIES, SELF, food_processor_switch_cargo_subtype_display_info, 
-	getbits(extra_callback_info2, 16, 8)) {
-	LVST: food_processor_switch_cargo_subtype_display_info_lvst;
-	GRAI: food_processor_switch_cargo_subtype_display_info_grai;
-	FISH: food_processor_switch_cargo_subtype_display_info_fish;
-	return 0x3800 + string(STR_EMPTY);
-}
-
-// getbits(extra_callback_info2, 8, 8) == 1 -> industry window, 0 -> industry buy/prospect window, 2 -> industry directory
-switch(FEAT_INDUSTRIES, SELF, food_processor_switch_cargo_subtype, 
-	 getbits(extra_callback_info2, 8, 8)) {
-	0: return CB_RESULT_IND_NO_TEXT_NO_AMOUNT;
-	1: food_processor_switch_cargo_subtype_display_info;
-	return 0x3800 + string(STR_EMPTY);
-}
-
 item(FEAT_INDUSTRIES, food_processor, INDUSTRY_ID_FOOD_PROCESSOR) {
 	property {
 		substitute: 0;
@@ -540,7 +500,7 @@ item(FEAT_INDUSTRIES, food_processor, INDUSTRY_ID_FOOD_PROCESSOR) {
 		random_prod_change:       return CB_RESULT_IND_PROD_NO_CHANGE;
 		location_check:           food_processor_switch_location_check_industry_distance;
 		//extra_text_industry:    food_processor_switch_extra_text;
-		cargo_subtype_display:    food_processor_switch_cargo_subtype;
+		cargo_subtype_display:    switch_cargo_subtype;
 	}
 }
     

--- a/src/industries/furniture_factory.pnml
+++ b/src/industries/furniture_factory.pnml
@@ -628,38 +628,6 @@ switch(FEAT_INDUSTRIES, SELF, furniture_factory_switch_produce,
 	furniture_factory_produce;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// cargo subtexts to show how much incoming cargo is waiting
-////////////////////////////////////////////////////////////////////////////////
-switch(FEAT_INDUSTRIES, SELF, furniture_factory_switch_cargo_subtype_display_info_plas, 
-	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("PLAS") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
-	 getbits(extra_callback_info2, 16, 8)]) {
-	PLAS: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
-	return 0x3800 + string(STR_EMPTY);
-}
-
-switch(FEAT_INDUSTRIES, SELF, furniture_factory_switch_cargo_subtype_display_info_wdpr, 
-	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("WDPR") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
-	 getbits(extra_callback_info2, 16, 8)]) {
-	WDPR: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
-	return 0x3800 + string(STR_EMPTY);
-}
-
-switch(FEAT_INDUSTRIES, SELF, furniture_factory_switch_cargo_subtype_display_info, 
-	getbits(extra_callback_info2, 16, 8)) {
-	PLAS: furniture_factory_switch_cargo_subtype_display_info_plas;
-	WDPR: furniture_factory_switch_cargo_subtype_display_info_wdpr;
-	return 0x3800 + string(STR_EMPTY);
-}
-
-// getbits(extra_callback_info2, 8, 8) == 1 -> industry window, 0 -> industry buy/prospect window, 2 -> industry directory
-switch(FEAT_INDUSTRIES, SELF, furniture_factory_switch_cargo_subtype, 
-	 getbits(extra_callback_info2, 8, 8)) {
-	0: return CB_RESULT_IND_NO_TEXT_NO_AMOUNT;
-	1: furniture_factory_switch_cargo_subtype_display_info;
-	return 0x3800 + string(STR_EMPTY);
-}
-
 item(FEAT_INDUSTRIES, furniture_factory, INDUSTRY_ID_FURNITURE_FACTORY) {
 	property {
 		substitute: 0;
@@ -688,7 +656,7 @@ item(FEAT_INDUSTRIES, furniture_factory, INDUSTRY_ID_FURNITURE_FACTORY) {
 		random_prod_change:       return CB_RESULT_IND_PROD_NO_CHANGE;
 		location_check:           furniture_factory_switch_location_check_industry_distance;
 		extra_text_fund:          return CB_RESULT_NO_TEXT;
-		cargo_subtype_display:    furniture_factory_switch_cargo_subtype;
+		cargo_subtype_display:    switch_cargo_subtype;
 	}
 }
     

--- a/src/industries/integrated_steel_mill.pnml
+++ b/src/industries/integrated_steel_mill.pnml
@@ -499,38 +499,6 @@ switch(FEAT_INDUSTRIES, SELF, steel_mill_switch_produce,
 	steel_mill_produce;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// cargo subtexts to show how much incoming cargo is waiting
-////////////////////////////////////////////////////////////////////////////////
-switch(FEAT_INDUSTRIES, SELF, steel_mill_switch_cargo_subtype_display_info_iore, 
-	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("IORE") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
-	 getbits(extra_callback_info2, 16, 8)]) {
-	IORE: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
-	return 0x3800 + string(STR_EMPTY);
-}
-
-switch(FEAT_INDUSTRIES, SELF, steel_mill_switch_cargo_subtype_display_info_coal, 
-	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("COAL") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
-	 getbits(extra_callback_info2, 16, 8)]) {
-	COAL: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
-	return 0x3800 + string(STR_EMPTY);
-}
-
-switch(FEAT_INDUSTRIES, SELF, steel_mill_switch_cargo_subtype_display_info, 
-	getbits(extra_callback_info2, 16, 8)) {
-	IORE: steel_mill_switch_cargo_subtype_display_info_iore;
-	COAL: steel_mill_switch_cargo_subtype_display_info_coal;
-	return 0x3800 + string(STR_EMPTY);
-}
-
-// getbits(extra_callback_info2, 8, 8) == 1 -> industry window, 0 -> industry buy/prospect window, 2 -> industry directory
-switch(FEAT_INDUSTRIES, SELF, steel_mill_switch_cargo_subtype, 
-	 getbits(extra_callback_info2, 8, 8)) {
-	0: return CB_RESULT_IND_NO_TEXT_NO_AMOUNT;
-	1: steel_mill_switch_cargo_subtype_display_info;
-	return 0x3800 + string(STR_EMPTY);
-}
-
 switch(FEAT_INDUSTRIES, SELF, steel_mill_switch_extra_text_fund, 
 	[STORE_TEMP(string(STR_1800), TEMP_REGISTER_EXTRA_TEXT_ARG0),
 	current_year]) {
@@ -574,7 +542,7 @@ item(FEAT_INDUSTRIES, steel_mill, INDUSTRY_ID_INTEGRATED_STEEL_MILL) {
 		location_check:           steel_mill_switch_location_check_industry_distance;
 		extra_text_fund:          steel_mill_switch_extra_text_fund;
 		//extra_text_industry:    steel_mill_switch_extra_text;
-		cargo_subtype_display:    steel_mill_switch_cargo_subtype;
+		cargo_subtype_display:    switch_cargo_subtype;
 	}
 }
     

--- a/src/industries/oil_refinery.pnml
+++ b/src/industries/oil_refinery.pnml
@@ -381,21 +381,6 @@ switch(FEAT_INDUSTRIES, SELF, oil_refinery_switch_produce,
 ////////////////////////////////////////////////////////////////////////////////
 // cargo subtexts to show how much incoming cargo is waiting
 ////////////////////////////////////////////////////////////////////////////////
-switch(FEAT_INDUSTRIES, SELF, oil_refinery_switch_cargo_subtype_display_info, 
-	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("OIL_") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
-	 getbits(extra_callback_info2, 16, 8)]) {
-	OIL_: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
-	return 0x3800 + string(STR_EMPTY);
-}
-
-// getbits(extra_callback_info2, 8, 8) == 1 -> industry window, 0 -> industry buy/prospect window, 2 -> industry directory
-switch(FEAT_INDUSTRIES, SELF, oil_refinery_switch_cargo_subtype, 
-	 getbits(extra_callback_info2, 8, 8)) {
-	0: return CB_RESULT_IND_NO_TEXT_NO_AMOUNT;
-	1: oil_refinery_switch_cargo_subtype_display_info;
-	return 0x3800 + string(STR_EMPTY);
-}
-
 switch(FEAT_INDUSTRIES, SELF, oil_refinery_switch_extra_text_fund, 
 	[STORE_TEMP(string(STR_1860), TEMP_REGISTER_EXTRA_TEXT_ARG0),
 	current_year]) {
@@ -438,7 +423,7 @@ item(FEAT_INDUSTRIES, oil_refinery, INDUSTRY_ID_OIL_REFINERY) {
 		random_prod_change:       return CB_RESULT_IND_PROD_NO_CHANGE;
 		location_check:           oil_refinery_switch_location_check_industry_distance;
 		extra_text_fund:          oil_refinery_switch_extra_text_fund;
-		cargo_subtype_display:    oil_refinery_switch_cargo_subtype;
+		cargo_subtype_display:    switch_cargo_subtype;
 	}
 }
     

--- a/src/industries/power_plant.pnml
+++ b/src/industries/power_plant.pnml
@@ -473,35 +473,6 @@ switch(FEAT_INDUSTRIES, SELF, power_plant_switch_check_availability, current_yea
 	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
 }
 
-switch(FEAT_INDUSTRIES, SELF, power_plant_switch_cargo_subtype_display_info_coal, 
-	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("COAL") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
-	 getbits(extra_callback_info2, 16, 8)]) {
-	COAL: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
-	return 0x3800 + string(STR_EMPTY);
-}
-
-switch(FEAT_INDUSTRIES, SELF, power_plant_switch_cargo_subtype_display_info_oil, 
-	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("OIL_") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
-	 getbits(extra_callback_info2, 16, 8)]) {
-	OIL_: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
-	return 0x3800 + string(STR_EMPTY);
-}
-
-// getbits(extra_callback_info2, 16, 8) contains the cargo type
-switch(FEAT_INDUSTRIES, SELF, power_plant_switch_cargo_subtype_display_info_cargo, 
-	getbits(extra_callback_info2, 16, 8)) {
-	COAL: power_plant_switch_cargo_subtype_display_info_coal;
-	OIL_: power_plant_switch_cargo_subtype_display_info_oil;
-	return 0x3800 + string(STR_EMPTY);
-}
-
-// getbits(extra_callback_info2, 8, 8) == 1 -> industry window, 0 -> industry buy/prospect window, 2 -> industry directory
-switch(FEAT_INDUSTRIES, SELF, power_plant_switch_cargo_subtype_display_info, getbits(extra_callback_info2, 8, 8))
-{
-	0: return CB_RESULT_IND_NO_TEXT_NO_AMOUNT;
-	1: power_plant_switch_cargo_subtype_display_info_cargo;
-}
-
 switch(FEAT_INDUSTRIES, SELF, power_plant_switch_prod_change_build,
 	[
 	// initialize the permanent registers
@@ -554,7 +525,7 @@ item(FEAT_INDUSTRIES, power_plant, INDUSTRY_ID_POWER_PLANT) {
         location_check:           power_plant_switch_location_check;
         extra_text_fund:          power_plant_switch_extra_text_fund;
 		extra_text_industry:      power_plant_switch_extra_text;
-        cargo_subtype_display:    power_plant_switch_cargo_subtype_display_info;
+        cargo_subtype_display:    switch_cargo_subtype;
     }
 }
     

--- a/src/industries/sawmill.pnml
+++ b/src/industries/sawmill.pnml
@@ -448,24 +448,6 @@ switch(FEAT_INDUSTRIES, SELF, sawmill_switch_produce,
 	sawmill_produce;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// cargo subtexts to show how much incoming cargo is waiting
-////////////////////////////////////////////////////////////////////////////////
-switch(FEAT_INDUSTRIES, SELF, sawmill_switch_cargo_subtype_display_info, 
-	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("WOOD") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
-	 getbits(extra_callback_info2, 16, 8)]) {
-	WOOD: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
-	return 0x3800 + string(STR_EMPTY);
-}
-
-// getbits(extra_callback_info2, 8, 8) == 1 -> industry window, 0 -> industry buy/prospect window, 2 -> industry directory
-switch(FEAT_INDUSTRIES, SELF, sawmill_switch_cargo_subtype, 
-	 getbits(extra_callback_info2, 8, 8)) {
-	0: return CB_RESULT_IND_NO_TEXT_NO_AMOUNT;
-	1: sawmill_switch_cargo_subtype_display_info;
-	return 0x3800 + string(STR_EMPTY);
-}
-
 item(FEAT_INDUSTRIES, sawmill, INDUSTRY_ID_SAWMILL) {
 	property {
 		substitute: 0;
@@ -492,7 +474,7 @@ item(FEAT_INDUSTRIES, sawmill, INDUSTRY_ID_SAWMILL) {
 		monthly_prod_change:      return CB_RESULT_IND_PROD_NO_CHANGE;
 		random_prod_change:       return CB_RESULT_IND_PROD_NO_CHANGE;
 		location_check:           sawmill_switch_location_check_industry_distance;
-		cargo_subtype_display:    sawmill_switch_cargo_subtype;
+		cargo_subtype_display:    switch_cargo_subtype;
 	}
 }
     

--- a/src/industries/vehicle_factory.pnml
+++ b/src/industries/vehicle_factory.pnml
@@ -649,30 +649,6 @@ switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_produce,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// cargo subtexts to show how much incoming cargo is waiting
-////////////////////////////////////////////////////////////////////////////////
-switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_cargo_subtype_display_info_steel, 
-	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("STEL") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
-	 getbits(extra_callback_info2, 16, 8)]) {
-	STEL: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
-	return 0x3800 + string(STR_EMPTY);
-}
-
-switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_cargo_subtype_display_info, 
-	getbits(extra_callback_info2, 16, 8)) {
-	STEL: vehicle_factory_switch_cargo_subtype_display_info_steel;
-	return 0x3800 + string(STR_EMPTY);
-}
-
-// getbits(extra_callback_info2, 8, 8) == 1 -> industry window, 0 -> industry buy/prospect window, 2 -> industry directory
-switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_cargo_subtype, 
-	 getbits(extra_callback_info2, 8, 8)) {
-	0: return CB_RESULT_IND_NO_TEXT_NO_AMOUNT;
-	1: vehicle_factory_switch_cargo_subtype_display_info;
-	return 0x3800 + string(STR_EMPTY);
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // build the industry window text here
 ////////////////////////////////////////////////////////////////////////////////
 switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_extra_text_electricity, 
@@ -746,7 +722,7 @@ item(FEAT_INDUSTRIES, vehicle_factory, INDUSTRY_ID_VEHICLE_FACTORY) {
 		location_check:           vehicle_factory_switch_location_check_industry_distance;
 		extra_text_fund:          vehicle_factory_switch_extra_text_fund;
 		extra_text_industry:      vehicle_factory_switch_extra_text;
-		cargo_subtype_display:    vehicle_factory_switch_cargo_subtype;
+		cargo_subtype_display:    switch_cargo_subtype;
 	}
 }
     


### PR DESCRIPTION
The cargo subtype display code is the same for almost all industries, so it should be shared among the industries.