### PR TITLE
fix: cargo subtype display only for relevant cargos

### DIFF
--- a/src/cargo_subtype_display.pnml
+++ b/src/cargo_subtype_display.pnml
@@ -8,9 +8,15 @@ switch(FEAT_INDUSTRIES, SELF, switch_cargo_subtype_display_info_coal,
 switch(FEAT_INDUSTRIES, SELF, switch_cargo_subtype_display_info_fish, 
 	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("FISH") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
 	 getbits(extra_callback_info2, 16, 8)]) {
-	//FISH: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
-	//return 0x3800 + string(STR_EMPTY);
-	return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
+	FISH: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
+	return 0x3800 + string(STR_EMPTY);
+}
+
+switch(FEAT_INDUSTRIES, SELF, switch_cargo_subtype_display_info_food, 
+	[STORE_TEMP(getbits(extra_callback_info2, 16, 8) | incoming_cargo_waiting("FOOD") << 16,TEMP_REGISTER_EXTRA_TEXT_ARG0),
+	 getbits(extra_callback_info2, 16, 8)]) {
+	FOOD: return 0x3800 + string(STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE);
+	return 0x3800 + string(STR_EMPTY);
 }
 
 switch(FEAT_INDUSTRIES, SELF, switch_cargo_subtype_display_info_grai, 
@@ -73,6 +79,7 @@ switch(FEAT_INDUSTRIES, SELF, switch_cargo_subtype_display_info,
 	getbits(extra_callback_info2, 16, 8)) {
 	COAL: switch_cargo_subtype_display_info_coal;
 	FISH: switch_cargo_subtype_display_info_fish;
+	FOOD: switch_cargo_subtype_display_info_food;
 	GRAI: switch_cargo_subtype_display_info_grai;
 	IORE: switch_cargo_subtype_display_info_iore;
 	LVST: switch_cargo_subtype_display_info_lvst;

--- a/src/industries/food_processor.pnml
+++ b/src/industries/food_processor.pnml
@@ -473,6 +473,14 @@ switch(FEAT_INDUSTRIES, SELF, food_processor_switch_produce,
 	food_processor_switch_produce_fish;
 }
 
+// only show stockpile for LVST, GRAI, FISH and nothing else
+switch(FEAT_INDUSTRIES, SELF, food_processor_switch_cargo_subtype, getbits(extra_callback_info2, 16, 8)) {
+	LVST: switch_cargo_subtype;
+	GRAI: switch_cargo_subtype;
+	FISH: switch_cargo_subtype;
+	return 0x3800 + string(STR_EMPTY);
+}
+
 item(FEAT_INDUSTRIES, food_processor, INDUSTRY_ID_FOOD_PROCESSOR) {
 	property {
 		substitute: 0;
@@ -500,7 +508,7 @@ item(FEAT_INDUSTRIES, food_processor, INDUSTRY_ID_FOOD_PROCESSOR) {
 		random_prod_change:       return CB_RESULT_IND_PROD_NO_CHANGE;
 		location_check:           food_processor_switch_location_check_industry_distance;
 		//extra_text_industry:    food_processor_switch_extra_text;
-		cargo_subtype_display:    switch_cargo_subtype;
+		cargo_subtype_display:    food_processor_switch_cargo_subtype;
 	}
 }
     

--- a/src/industries/furniture_factory.pnml
+++ b/src/industries/furniture_factory.pnml
@@ -628,6 +628,12 @@ switch(FEAT_INDUSTRIES, SELF, furniture_factory_switch_produce,
 	furniture_factory_produce;
 }
 
+switch(FEAT_INDUSTRIES, SELF, furniture_factory_switch_cargo_subtype, getbits(extra_callback_info2, 16, 8)) {
+	WDPR: switch_cargo_subtype;
+	PLAS: switch_cargo_subtype;
+	return 0x3800 + string(STR_EMPTY);
+}
+
 item(FEAT_INDUSTRIES, furniture_factory, INDUSTRY_ID_FURNITURE_FACTORY) {
 	property {
 		substitute: 0;
@@ -656,7 +662,7 @@ item(FEAT_INDUSTRIES, furniture_factory, INDUSTRY_ID_FURNITURE_FACTORY) {
 		random_prod_change:       return CB_RESULT_IND_PROD_NO_CHANGE;
 		location_check:           furniture_factory_switch_location_check_industry_distance;
 		extra_text_fund:          return CB_RESULT_NO_TEXT;
-		cargo_subtype_display:    switch_cargo_subtype;
+		cargo_subtype_display:    furniture_factory_switch_cargo_subtype;
 	}
 }
     

--- a/src/industries/integrated_steel_mill.pnml
+++ b/src/industries/integrated_steel_mill.pnml
@@ -513,6 +513,12 @@ switch(FEAT_INDUSTRIES, SELF, steel_mill_switch_check_availability,
 	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
 }
 
+switch(FEAT_INDUSTRIES, SELF, steel_mill_switch_cargo_subtype, getbits(extra_callback_info2, 16, 8)) {
+	COAL: switch_cargo_subtype;
+	IORE: switch_cargo_subtype;
+	return 0x3800 + string(STR_EMPTY);
+}
+
 item(FEAT_INDUSTRIES, steel_mill, INDUSTRY_ID_INTEGRATED_STEEL_MILL) {
 	property {
 		substitute: 0;
@@ -542,7 +548,7 @@ item(FEAT_INDUSTRIES, steel_mill, INDUSTRY_ID_INTEGRATED_STEEL_MILL) {
 		location_check:           steel_mill_switch_location_check_industry_distance;
 		extra_text_fund:          steel_mill_switch_extra_text_fund;
 		//extra_text_industry:    steel_mill_switch_extra_text;
-		cargo_subtype_display:    switch_cargo_subtype;
+		cargo_subtype_display:    steel_mill_switch_cargo_subtype;
 	}
 }
     

--- a/src/industries/power_plant.pnml
+++ b/src/industries/power_plant.pnml
@@ -495,6 +495,12 @@ switch(FEAT_INDUSTRIES, SELF, power_plant_switch_extra_text,
 	return string(STR_POWER_PLANT_TEXT);
 }
 
+switch(FEAT_INDUSTRIES, SELF, power_plant_switch_cargo_subtype, getbits(extra_callback_info2, 16, 8)) {
+	COAL: switch_cargo_subtype;
+	OIL_: switch_cargo_subtype;
+	return 0x3800 + string(STR_EMPTY);
+}
+
 item(FEAT_INDUSTRIES, power_plant, INDUSTRY_ID_POWER_PLANT) {
 	property {
 		substitute: 0;
@@ -524,8 +530,7 @@ item(FEAT_INDUSTRIES, power_plant, INDUSTRY_ID_POWER_PLANT) {
         monthly_prod_change:      return CB_RESULT_IND_PROD_NO_CHANGE;
         location_check:           power_plant_switch_location_check;
         extra_text_fund:          power_plant_switch_extra_text_fund;
-		extra_text_industry:      power_plant_switch_extra_text;
-        cargo_subtype_display:    switch_cargo_subtype;
+	extra_text_industry:      power_plant_switch_extra_text;
+        cargo_subtype_display:    power_plant_switch_cargo_subtype;
     }
 }
-    

--- a/src/industries/sawmill.pnml
+++ b/src/industries/sawmill.pnml
@@ -448,6 +448,13 @@ switch(FEAT_INDUSTRIES, SELF, sawmill_switch_produce,
 	sawmill_produce;
 }
 
+// only show stockpile for WOOD and nothing else
+switch(FEAT_INDUSTRIES, SELF, sawmill_switch_cargo_subtype, getbits(extra_callback_info2, 16, 8)) {
+	WOOD: switch_cargo_subtype;
+	return 0x3800 + string(STR_EMPTY);
+}
+
+
 item(FEAT_INDUSTRIES, sawmill, INDUSTRY_ID_SAWMILL) {
 	property {
 		substitute: 0;
@@ -474,7 +481,6 @@ item(FEAT_INDUSTRIES, sawmill, INDUSTRY_ID_SAWMILL) {
 		monthly_prod_change:      return CB_RESULT_IND_PROD_NO_CHANGE;
 		random_prod_change:       return CB_RESULT_IND_PROD_NO_CHANGE;
 		location_check:           sawmill_switch_location_check_industry_distance;
-		cargo_subtype_display:    switch_cargo_subtype;
+		cargo_subtype_display:    sawmill_switch_cargo_subtype;
 	}
 }
-    

--- a/src/industries/vehicle_factory.pnml
+++ b/src/industries/vehicle_factory.pnml
@@ -693,6 +693,13 @@ switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_check_availability,
 	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
 }
 
+// only show stockpile for STEL, PLAS and nothing else
+switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_cargo_subtype, getbits(extra_callback_info2, 16, 8)) {
+	STEL: switch_cargo_subtype;
+	PLAS: switch_cargo_subtype;
+	return 0x3800 + string(STR_EMPTY);
+}
+
 item(FEAT_INDUSTRIES, vehicle_factory, INDUSTRY_ID_VEHICLE_FACTORY) {
 	property {
 		substitute: 0;
@@ -722,7 +729,6 @@ item(FEAT_INDUSTRIES, vehicle_factory, INDUSTRY_ID_VEHICLE_FACTORY) {
 		location_check:           vehicle_factory_switch_location_check_industry_distance;
 		extra_text_fund:          vehicle_factory_switch_extra_text_fund;
 		extra_text_industry:      vehicle_factory_switch_extra_text;
-		cargo_subtype_display:    switch_cargo_subtype;
+		cargo_subtype_display:    vehicle_factory_switch_cargo_subtype;
 	}
 }
-    


### PR DESCRIPTION
Cargo subtype display would display information on stockpiles also for cargos that are produced, which does not make sense. The solution is to filter properly.