### PR TITLE
fix: cargo callback issues

### DIFF
--- a/src/industries/builders_yard.pnml
+++ b/src/industries/builders_yard.pnml
@@ -292,8 +292,20 @@ switch(FEAT_INDUSTRIES, SELF, builders_yard_switch_location_check_industry_dista
 	   return CB_RESULT_LOCATION_DISALLOW;
 }
 
-// take all incoming cargo and produce nothing
 produce(builders_yard_produce,
+	[WDPR: LOAD_TEMP(TEMP_REGISTER_INCOMING_CARGO_WAITING0);
+	],
+	[],
+	0 // do not run again
+)
+
+switch(FEAT_INDUSTRIES, SELF, builders_yard_switch_produce,
+	[STORE_TEMP(incoming_cargo_waiting("WDPR"), TEMP_REGISTER_INCOMING_CARGO_WAITING0)]) {
+	builders_yard_produce; 
+}
+
+// take all incoming cargo and produce nothing
+produce(builders_yard_produce_extension_building_industry,
 	[WDPR: LOAD_TEMP(TEMP_REGISTER_INCOMING_CARGO_WAITING0);
 	 CMNT: LOAD_TEMP(TEMP_REGISTER_INCOMING_CARGO_WAITING1);
 	 SAND: LOAD_TEMP(TEMP_REGISTER_INCOMING_CARGO_WAITING2);
@@ -303,13 +315,13 @@ produce(builders_yard_produce,
 	0 // do not run again
 )
 
-switch(FEAT_INDUSTRIES, SELF, builders_yard_switch_produce,
+switch(FEAT_INDUSTRIES, SELF, builders_yard_switch_produce_extension_building_industry,
 	[STORE_TEMP(incoming_cargo_waiting("WDPR"), TEMP_REGISTER_INCOMING_CARGO_WAITING0),
 	 STORE_TEMP(incoming_cargo_waiting("CMNT"), TEMP_REGISTER_INCOMING_CARGO_WAITING1),
 	 STORE_TEMP(incoming_cargo_waiting("SAND"), TEMP_REGISTER_INCOMING_CARGO_WAITING2),
 	 STORE_TEMP(incoming_cargo_waiting("BDMT"), TEMP_REGISTER_INCOMING_CARGO_WAITING3),
 	]) {
-	builders_yard_produce; 
+	builders_yard_produce_extension_building_industry; 
 }
 
 item(FEAT_INDUSTRIES, builders_yard, INDUSTRY_ID_BUILDERS_YARD) {
@@ -333,6 +345,17 @@ item(FEAT_INDUSTRIES, builders_yard, INDUSTRY_ID_BUILDERS_YARD) {
 			cargo_types: [accept_cargo("WDPR"),accept_cargo("SAND"),accept_cargo("CMNT"),accept_cargo("BDMT")];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_BUILDERS_YARD));
 		}
+		graphics {
+			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			produce_cargo_arrival:    empty_produce; 
+			produce_256_ticks:        builders_yard_switch_produce_extension_building_industry;
+			monthly_prod_change:      CB_RESULT_IND_PROD_NO_CHANGE;
+			random_prod_change:       CB_RESULT_IND_PROD_NO_CHANGE;
+			location_check:           builders_yard_switch_location_check_industry_distance;
+			extra_text_fund:          return CB_RESULT_NO_TEXT;
+			extra_text_industry:      return CB_RESULT_NO_TEXT;
+			cargo_subtype_display:    return CB_RESULT_IND_NO_TEXT_NO_AMOUNT;
+		}
 	} // param_extension_building_materials
 	
 	if (!param_extension_building_materials) {
@@ -355,8 +378,6 @@ item(FEAT_INDUSTRIES, builders_yard, INDUSTRY_ID_BUILDERS_YARD) {
 			cargo_types: [accept_cargo("WDPR")];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_BUILDERS_YARD));
 		}
-	} // !param_extension_building_materials
-        
 	graphics {
 		construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
 		produce_cargo_arrival:    empty_produce; 
@@ -368,4 +389,7 @@ item(FEAT_INDUSTRIES, builders_yard, INDUSTRY_ID_BUILDERS_YARD) {
 		extra_text_industry:      return CB_RESULT_NO_TEXT;
 		cargo_subtype_display:    return CB_RESULT_IND_NO_TEXT_NO_AMOUNT;
 	}
+	} // !param_extension_building_materials
+        
+	
 }

--- a/src/industries/food_processor.pnml
+++ b/src/industries/food_processor.pnml
@@ -394,7 +394,6 @@ switch(FEAT_INDUSTRIES, SELF, food_processor_switch_location_check_industry_dist
 	   return CB_RESULT_LOCATION_DISALLOW;
 }
 
-// TODO: scale food production down to 50%?
 produce(food_processor_produce,
 	[LVST: LOAD_TEMP(TEMP_REGISTER_PRODUCTION_RAW0);
 	 GRAI: LOAD_TEMP(TEMP_REGISTER_PRODUCTION_RAW1);


### PR DESCRIPTION
Due to missing checks for enabled extensions, callbacks for nonexisting cargos would be executed.