### PR TITLE
fix: cargo subtype display for oil refinery was incorrect

### DIFF
--- a/src/industries/oil_refinery.pnml
+++ b/src/industries/oil_refinery.pnml
@@ -395,6 +395,11 @@ switch(FEAT_INDUSTRIES, SELF, oil_refinery_switch_check_availability,
 	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
 }
 
+switch(FEAT_INDUSTRIES, SELF, oil_refinery_switch_cargo_subtype, getbits(extra_callback_info2, 16, 8)) {
+	OIL_: switch_cargo_subtype;
+	return 0x3800 + string(STR_EMPTY);
+}
+
 item(FEAT_INDUSTRIES, oil_refinery, INDUSTRY_ID_OIL_REFINERY) {
 	property {
 		substitute: 0;
@@ -423,7 +428,7 @@ item(FEAT_INDUSTRIES, oil_refinery, INDUSTRY_ID_OIL_REFINERY) {
 		random_prod_change:       return CB_RESULT_IND_PROD_NO_CHANGE;
 		location_check:           oil_refinery_switch_location_check_industry_distance;
 		extra_text_fund:          oil_refinery_switch_extra_text_fund;
-		cargo_subtype_display:    switch_cargo_subtype;
+		cargo_subtype_display:    oil_refinery_switch_cargo_subtype;
 	}
 }
     


### PR DESCRIPTION
Oil refinery showed unnecessary stockpiling information for produced goods.