### PR TITLE
fix: make plastics an optional cargo for the vehicle factory

### DIFF
--- a/lang/english.lng
+++ b/lang/english.lng
@@ -220,13 +220,15 @@ STR_INDUSTRY_NO_POWER :{RED}No power available, production stopped!
 STR_INDUSTRY_NOT_ENOUGH_POWER :{YELLOW}Not enough power available, production reduced!
 STR_INDUSTRY_ENOUGH_POWER :{GREEN}Enough power available.
 
+STR_INDUSTRY_ELECTRICITY_OPTIONAL_CARGO_TEXT :Industry can produce {YELLOW}{COMMA}{BLACK} items ({YELLOW}{COMMA}{BLACK}% of maximum production){}Maximum production requires {YELLOW}{COMMA}{BLACK} power.{}{STRING}{}{BLACK}{STRING}
+
 # Funding window text
 STR_INDUSTRY_NOT_AVAILABLE_BEFORE :{}{BLACK}Industry not available before {STRING}.
 STR_INDUSTRY_AVAILABLE_TIMEFRAME  :{}{BLACK}Industry only available between {STRING} and {STRING}.
 
 # Cargo display for stockpile
-STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE          :{BLACK}({CARGO_SHORT} in stock)
-STR_CARGO_SUBTYPE_DISPLAY_OPTIONAL_CARGO_AVAILABLE :{WHITE}({CARGO_SHORT} in stock)
+STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE          :{BLACK} ({CARGO_SHORT} in stock)
+STR_CARGO_SUBTYPE_DISPLAY_OPTIONAL_CARGO_AVAILABLE :{WHITE} ({CARGO_SHORT} in stock)
 
 # Error texts
 STR_ERR_OPENTTD_VERSION:{ORANGE}E00:{TITLE} requires OpenTTD 14.0 or newer

--- a/lang/german.lng
+++ b/lang/german.lng
@@ -170,7 +170,7 @@ STR_INDUSTRY_NEEDS_ANY_INPUT :Industrie beginnt Produktion sobald wenigstens ein
 
 # Texte für Energiewirtschaft, Kraftwerke zeigen die Produktion, Industrien zeigen an wie viel Strom sie benötigen und ob der Bedarf gedeckt ist
 STR_POWER_PLANT_TEXT :Stromproduktion {YELLOW}{COMMA}{BLACK}, Bedarf {YELLOW}{COMMA}{BLACK}
-STR_INDUSTRY_ELECTRICITY_TEXT :Industrie kann {YELLOW}{COMMA}{BLACK} Einheiten produzieren ({YELLOW}{COMMA}{BLACK}% der maximalen Produktion){}Maximale Produktion benötigt {YELLOW}{COMMA}{BLACK} Strom.{}{STRING}
+STR_INDUSTRY_ELECTRICITY_TEXT :Industrie kann {YELLOW}{COMMA}{BLACK} Einheiten produzieren ({YELLOW}{COMMA}{BLACK}% der maximalen Produktion){}Maximale Produktion benötigt {YELLOW}{COMMA}{BLACK} Strom.{}{BLACK}{STRING}
 STR_INDUSTRY_NO_POWER :{RED}Kein Strom verfügbar, Produktion gestoppt!
 STR_INDUSTRY_NOT_ENOUGH_POWER :{YELLOW}Nicht genug Strom verfügbar, Produktion reduziert!
 STR_INDUSTRY_ENOUGH_POWER :{GREEN}Genug Strom verfügbar.
@@ -180,8 +180,8 @@ STR_INDUSTRY_NOT_AVAILABLE_BEFORE :{}{BLACK}Industrie erst ab {STRING} verfügba
 STR_INDUSTRY_AVAILABLE_TIMEFRAME  :{}{BLACK}Industrie nur zwischen {STRING} und {STRING} verfügbar.
 
 # Display für Vorratsanzeige
-STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE          :{BLACK}({CARGO_SHORT} vorrätig)
-STR_CARGO_SUBTYPE_DISPLAY_OPTIONAL_CARGO_AVAILABLE :{WHITE}({CARGO_SHORT} vorrätig)
+STR_CARGO_SUBTYPE_DISPLAY_CARGO_AVAILABLE          :{BLACK} ({CARGO_SHORT} vorrätig)
+STR_CARGO_SUBTYPE_DISPLAY_OPTIONAL_CARGO_AVAILABLE :{WHITE} ({CARGO_SHORT} vorrätig)
 
 # Fehlertexte
 STR_ERR_OPENTTD_VERSION             :{ORANGE}E00: {TITLE} benötigt OpenTTD 14.0 oder neuer

--- a/src/industries/aluminium_plant.pnml
+++ b/src/industries/aluminium_plant.pnml
@@ -1387,7 +1387,7 @@ if (param_extension_aluminium && !param_extension_basic_inorganic_chemistry) {
 	item(FEAT_INDUSTRIES, aluminium_plant, INDUSTRY_ID_ALUMINIUM_PLANT) {
 		property {
 			substitute: 0;
-			map_colour: 9;
+			map_colour: 13;
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [aluminium_plant_tilelayout_1, aluminium_plant_tilelayout_2, aluminium_plant_tilelayout_3];
@@ -1422,7 +1422,7 @@ if (param_extension_aluminium && param_extension_basic_inorganic_chemistry) {
 	item(FEAT_INDUSTRIES, aluminium_plant, INDUSTRY_ID_ALUMINIUM_PLANT) {
 		property {
 			substitute: 0;
-			map_colour: 9;
+			map_colour: 13;
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [aluminium_plant_tilelayout_1, aluminium_plant_tilelayout_2, aluminium_plant_tilelayout_3];

--- a/src/industries/paint_factory.pnml
+++ b/src/industries/paint_factory.pnml
@@ -685,7 +685,7 @@ if (param_extension_painting_industries && param_extension_building_materials) {
 	item(FEAT_INDUSTRIES, paint_factory, INDUSTRY_ID_PAINT_FACTORY) {
 		property {
 			substitute: 0;
-			map_colour: 6;
+			map_colour: 45;
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [paint_factory_tilelayout_1,paint_factory_tilelayout_2];

--- a/src/industries/vehicle_factory.pnml
+++ b/src/industries/vehicle_factory.pnml
@@ -733,11 +733,16 @@ switch(FEAT_INDUSTRIES, SELF, vehicle_factory_update_production_according_to_pow
 }
 
 switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_produce, 
-	[STORE_TEMP(min(incoming_cargo_waiting("STEL"),incoming_cargo_waiting("PLAS")), TEMP_REGISTER_INCOMING_CARGO_WAITING0),
+	[STORE_TEMP(incoming_cargo_waiting("STEL"), TEMP_REGISTER_INCOMING_CARGO_WAITING0),
 	 
 	 calculate_raw_material_usage(),
 	 calculate_total_production(),
 	 
+	 STORE_TEMP(incoming_cargo_waiting("PLAS"),TEMP_REGISTER_INCOMING_CARGO_WAITING1),
+	 STORE_TEMP(LOAD_TEMP(TEMP_REGISTER_INCOMING_CARGO_WAITING1) > 0 ? 1 : 0, TEMP_REGISTER_NUMBER_OF_WAITING_CARGOS),
+	// if no optional cargo available, limit production to 128t, with 1 cargo available there is no limit
+	STORE_TEMP(LOAD_TEMP(TEMP_REGISTER_NUMBER_OF_WAITING_CARGOS) == 1 ? LOAD_TEMP(TEMP_REGISTER_CURRENT_PRODUCTION_AMOUNT) : min(16 + 8*LOAD_TEMP(TEMP_REGISTER_NUMBER_OF_WAITING_CARGOS),LOAD_TEMP(TEMP_REGISTER_CURRENT_PRODUCTION_AMOUNT)), TEMP_REGISTER_CURRENT_PRODUCTION_AMOUNT),
+		 
 	 store_debug_production_data(),
 	
 	 param_electricity_needed
@@ -747,9 +752,15 @@ switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_produce,
 }
 
 switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_produce_ext_aluminium, 
-	[STORE_TEMP(min(incoming_cargo_waiting("STEL"),incoming_cargo_waiting("PLAS"),incoming_cargo_waiting("ALUM")), TEMP_REGISTER_INCOMING_CARGO_WAITING0),
+	[STORE_TEMP(min(incoming_cargo_waiting("STEL"),incoming_cargo_waiting("ALUM")), TEMP_REGISTER_INCOMING_CARGO_WAITING0),
 	 calculate_raw_material_usage(),
 	 calculate_total_production(),
+	 
+	 STORE_TEMP(incoming_cargo_waiting("PLAS"),TEMP_REGISTER_INCOMING_CARGO_WAITING1),
+	 STORE_TEMP(LOAD_TEMP(TEMP_REGISTER_INCOMING_CARGO_WAITING1) > 0 ? 1 : 0, TEMP_REGISTER_NUMBER_OF_WAITING_CARGOS),
+	// if no optional cargo available, limit production to 128t, with 1 cargo available there is no limit
+	STORE_TEMP(LOAD_TEMP(TEMP_REGISTER_NUMBER_OF_WAITING_CARGOS) == 1 ? LOAD_TEMP(TEMP_REGISTER_CURRENT_PRODUCTION_AMOUNT) : min(16 + 8*LOAD_TEMP(TEMP_REGISTER_NUMBER_OF_WAITING_CARGOS),LOAD_TEMP(TEMP_REGISTER_CURRENT_PRODUCTION_AMOUNT)), TEMP_REGISTER_CURRENT_PRODUCTION_AMOUNT),
+	 
 	 store_debug_production_data(),
 	 param_electricity_needed
 	]) {
@@ -758,9 +769,14 @@ switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_produce_ext_aluminium,
 }
 
 switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_produce_ext_painting_industries, 
-	[STORE_TEMP(min(incoming_cargo_waiting("STEL"),incoming_cargo_waiting("PLAS"),incoming_cargo_waiting("COAT")), TEMP_REGISTER_INCOMING_CARGO_WAITING0),
+	[STORE_TEMP(min(incoming_cargo_waiting("STEL"),incoming_cargo_waiting("COAT")), TEMP_REGISTER_INCOMING_CARGO_WAITING0),
 	 calculate_raw_material_usage(),
 	 calculate_total_production(),
+	 
+	 STORE_TEMP(incoming_cargo_waiting("PLAS"),TEMP_REGISTER_INCOMING_CARGO_WAITING1),
+	 STORE_TEMP(LOAD_TEMP(TEMP_REGISTER_INCOMING_CARGO_WAITING1) > 0 ? 1 : 0, TEMP_REGISTER_NUMBER_OF_WAITING_CARGOS),
+	// if no optional cargo available, limit production to 128t, with 1 cargo available there is no limit
+	STORE_TEMP(LOAD_TEMP(TEMP_REGISTER_NUMBER_OF_WAITING_CARGOS) == 1 ? LOAD_TEMP(TEMP_REGISTER_CURRENT_PRODUCTION_AMOUNT) : min(16 + 8*LOAD_TEMP(TEMP_REGISTER_NUMBER_OF_WAITING_CARGOS),LOAD_TEMP(TEMP_REGISTER_CURRENT_PRODUCTION_AMOUNT)), TEMP_REGISTER_CURRENT_PRODUCTION_AMOUNT),
 	 
 	 param_electricity_needed
 	]) {
@@ -769,9 +785,14 @@ switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_produce_ext_painting_indust
 }
 
 switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_produce_ext_aluminium_ext_painting_industries, 
-	[STORE_TEMP(min(incoming_cargo_waiting("STEL"),incoming_cargo_waiting("PLAS"),incoming_cargo_waiting("ALUM"),incoming_cargo_waiting("COAT")), TEMP_REGISTER_INCOMING_CARGO_WAITING0),
+	[STORE_TEMP(min(incoming_cargo_waiting("STEL"),incoming_cargo_waiting("ALUM"),incoming_cargo_waiting("COAT")), TEMP_REGISTER_INCOMING_CARGO_WAITING0),
 	 calculate_raw_material_usage(),
 	 calculate_total_production(),
+	 
+	 STORE_TEMP(incoming_cargo_waiting("PLAS"),TEMP_REGISTER_INCOMING_CARGO_WAITING1),
+	 STORE_TEMP(LOAD_TEMP(TEMP_REGISTER_INCOMING_CARGO_WAITING1) > 0 ? 1 : 0, TEMP_REGISTER_NUMBER_OF_WAITING_CARGOS),
+	// if no optional cargo available, limit production to 128t, with 1 cargo available there is no limit
+	STORE_TEMP(LOAD_TEMP(TEMP_REGISTER_NUMBER_OF_WAITING_CARGOS) == 1 ? LOAD_TEMP(TEMP_REGISTER_CURRENT_PRODUCTION_AMOUNT) : min(16 + 8*LOAD_TEMP(TEMP_REGISTER_NUMBER_OF_WAITING_CARGOS),LOAD_TEMP(TEMP_REGISTER_CURRENT_PRODUCTION_AMOUNT)), TEMP_REGISTER_CURRENT_PRODUCTION_AMOUNT),
 	 
 	 param_electricity_needed
 	]) {
@@ -798,10 +819,10 @@ switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_extra_text_electricity,
 	 STORE_TEMP((LOAD_PERM(PERM_REGISTER_PRODUCTION_PERCENTAGE) == 0 && LOAD_PERM(PERM_REGISTER_MAXIMUM_PRODUCTION_AMOUNT) > 0) ? string(STR_INDUSTRY_NO_POWER) :
 	 ((LOAD_PERM(PERM_REGISTER_PRODUCTION_PERCENTAGE) == 100 && LOAD_PERM(PERM_REGISTER_MAXIMUM_PRODUCTION_AMOUNT) > 0) ? string(STR_INDUSTRY_ENOUGH_POWER) :
 	 ((LOAD_PERM(PERM_REGISTER_MAXIMUM_PRODUCTION_AMOUNT) > 0) ? string(STR_INDUSTRY_NOT_ENOUGH_POWER) : string(STR_EMPTY)))
-	 | string(STR_EMPTY) << 16, TEMP_REGISTER_EXTRA_TEXT_ARG3)
+	 | string(STR_INDUSTRY_HAS_OPTIONAL_INPUT_CARGO) << 16, TEMP_REGISTER_EXTRA_TEXT_ARG3)
 	])
 {
-	return string(STR_INDUSTRY_ELECTRICITY_TEXT);
+	return string(STR_INDUSTRY_ELECTRICITY_OPTIONAL_CARGO_TEXT);
 }
 
 switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_extra_text, param_electricity_needed)
@@ -828,7 +849,7 @@ switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_cargo_subtype, getbits(extr
 	ALUM: switch_cargo_subtype;
 	COAT: switch_cargo_subtype;
 	STEL: switch_cargo_subtype;
-	PLAS: switch_cargo_subtype;
+	PLAS: switch_cargo_subtype_white;
 	return 0x3800 + string(STR_EMPTY);
 }
 


### PR DESCRIPTION
This changeset fixes an issue with the vehicle factory requiring plastics from the beginning, but they only become available 20 years after the vehicle factory. Now the production is possible, although limited to 128 vehicles per month.