### PR TITLE
fix: ignore location checks when funding/prospecting industries

### DIFF
--- a/src/industries/acid_plant.pnml
+++ b/src/industries/acid_plant.pnml
@@ -929,13 +929,13 @@ tilelayout acid_plant_tilelayout_6 {
 switch(FEAT_INDUSTRIES, SELF, acid_plant_switch_location_check_industry_distance,
        [STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_CHLOR_ALKALI_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_ORE_SMELTER) >= 32) && 
 		(industry_distance(INDUSTRY_ID_POWER_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_OIL_REFINERY) >= 32) && 
 		(industry_distance(INDUSTRY_ID_COKE_OVEN) >= 32) && 
-	    (industry_distance(INDUSTRY_ID_ACID_PLANT) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_ACID_PLANT) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/aluminium_plant.pnml
+++ b/src/industries/aluminium_plant.pnml
@@ -1214,7 +1214,7 @@ tilelayout aluminium_plant_tilelayout_3 {
 switch(FEAT_INDUSTRIES, SELF, aluminium_plant_switch_location_check_industry_distance,
        [STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || (distance_from_town() && 
 		(industry_town_count(INDUSTRY_ID_POWER_PLANT) > 0) && // industry requires a power plant in the city
 		(industry_town_count(INDUSTRY_ID_ALUMINIUM_PLANT) == 0) && // only allow one plant per city
 		(industry_distance(INDUSTRY_ID_PORT) >= 32) && 

--- a/src/industries/ammonia_plant.pnml
+++ b/src/industries/ammonia_plant.pnml
@@ -1056,13 +1056,13 @@ tilelayout ammonia_plant_tilelayout_7 {
 }
 
 switch(FEAT_INDUSTRIES, SELF, ammonia_plant_switch_location_check_industry_distance,
-	   (industry_distance(INDUSTRY_ID_CRYO_PLANT) >= 32) &&
+	   (is_industry_funded_or_prospected()) || ((industry_distance(INDUSTRY_ID_CRYO_PLANT) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_ACID_PLANT) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_PHARMACEUTICAL_PLANT) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_SODA_PLANT) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_AMMONIA_PLANT) >= 16) &&
 	   (town_euclidean_dist(0,0) > 32) // should not be near towns
-	   ) 
+	   ) )
 {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;

--- a/src/industries/animal_farm.pnml
+++ b/src/industries/animal_farm.pnml
@@ -329,14 +329,14 @@ tilelayout animal_farm_industry_layout_3_tilelayout {
 }
 
 switch(FEAT_INDUSTRIES, SELF, animal_farm_switch_location_check_industry_distance,
-	   (industry_distance(INDUSTRY_ID_ANIMAL_FARM) >= 16) &&
+	   (is_industry_funded_or_prospected()) || ((industry_distance(INDUSTRY_ID_ANIMAL_FARM) >= 16) &&
 	   (industry_distance(INDUSTRY_ID_FOOD_PROCESSOR) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_DAIRY) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_TEXTILE_MILL) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_FARM) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_TEXTILE_MILL) >= 32) &&
 	   (town_euclidean_dist(0,0) > 32) // should not be near towns
-	   ) 
+	   ) )
 {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;

--- a/src/industries/biorefinery.pnml
+++ b/src/industries/biorefinery.pnml
@@ -977,7 +977,7 @@ tilelayout biorefinery_tilelayout_4 {
 switch(FEAT_INDUSTRIES, SELF, biorefinery_switch_location_check_industry_distance,
        [STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || (distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_PLASTICS_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PHARMACEUTICAL_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PETROL_STATION) >= 32) && 

--- a/src/industries/brewery.pnml
+++ b/src/industries/brewery.pnml
@@ -427,7 +427,7 @@ tilelayout brewery_tilelayout_5 {
 switch(FEAT_INDUSTRIES, SELF, brewery_switch_location_check_industry_distance,
        [STORE_TEMP(0, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(24, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || (distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_FARM) >= 32) &&
 	    (industry_distance(INDUSTRY_ID_GENERAL_STORE) >= 32) &&
 		(industry_distance(INDUSTRY_ID_HOTEL) >= 32) &&

--- a/src/industries/brick_works.pnml
+++ b/src/industries/brick_works.pnml
@@ -539,11 +539,11 @@ tilelayout brick_works_tilelayout_3 {
 switch(FEAT_INDUSTRIES, SELF, brick_works_switch_location_check_industry_distance,
 	[STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	 STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
         (industry_distance(INDUSTRY_ID_BRICK_WORKS) >= 16) && 
 		(industry_distance(INDUSTRY_ID_BUILDERS_YARD) >= 32) &&
 		(industry_distance(INDUSTRY_ID_PORT) >= 32) &&
-	     (industry_distance(INDUSTRY_ID_COAL_MINE) >= 32))]) {
+	     (industry_distance(INDUSTRY_ID_COAL_MINE) >= 32)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/builders_yard.pnml
+++ b/src/industries/builders_yard.pnml
@@ -289,7 +289,7 @@ tilelayout builders_yard_tilelayout_4 {
 }
 
 switch(FEAT_INDUSTRIES, SELF, builders_yard_switch_location_check_industry_distance,
-       [(
+       [(is_industry_funded_or_prospected()) || (
 	    (industry_distance(INDUSTRY_ID_CEMENT_PLANT) >= 32) &&
 		(industry_distance(INDUSTRY_ID_BRICK_WORKS) >= 32) &&
 		(town_euclidean_dist(0,0) < 16) &&

--- a/src/industries/carbon_black_plant.pnml
+++ b/src/industries/carbon_black_plant.pnml
@@ -484,13 +484,13 @@ tilelayout carbon_black_plant_tilelayout_3 {
 switch(FEAT_INDUSTRIES, SELF, carbon_black_plant_switch_location_check_industry_distance,
 	[STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	 STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
         (industry_distance(INDUSTRY_ID_PAINT_FACTORY) >= 32) && 
 	    (industry_distance(INDUSTRY_ID_OIL_WELL) >= 32) && 
 		(industry_distance(INDUSTRY_ID_OIL_RIG) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PORT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_COAL_MINE) >= 32) && 
-	    (industry_distance(INDUSTRY_ID_CARBON_BLACK_PLANT) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_CARBON_BLACK_PLANT) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/cement_plant.pnml
+++ b/src/industries/cement_plant.pnml
@@ -956,11 +956,11 @@ tilelayout cement_plant_tilelayout_5 {
 switch(FEAT_INDUSTRIES, SELF, cement_plant_switch_location_check_industry_distance,
 	[STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	 STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
         (industry_distance(INDUSTRY_ID_SANDPIT) >= 32) && 
 	    (industry_distance(INDUSTRY_ID_LIMESTONE_MINE) >= 32) &&
 		(industry_distance(INDUSTRY_ID_BUILDERS_YARD) >= 32) &&
-	     (industry_distance(INDUSTRY_ID_CEMENT_PLANT) >= 16))]) {
+	     (industry_distance(INDUSTRY_ID_CEMENT_PLANT) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/chlor_alkali_plant.pnml
+++ b/src/industries/chlor_alkali_plant.pnml
@@ -761,7 +761,7 @@ tilelayout chlor_alkali_plant_tilelayout_6 {
 switch(FEAT_INDUSTRIES, SELF, chlor_alkali_plant_switch_location_check_industry_distance,
        [STORE_TEMP(24, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(128, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 		(industry_town_count(INDUSTRY_ID_POWER_PLANT) > 0) && // industry requires a power plant in the city
 		(industry_town_count(INDUSTRY_ID_CHLOR_ALKALI_PLANT) == 0) && // only allow one factory per city
 		(industry_distance(INDUSTRY_ID_PLASTICS_PLANT) >= 32) &&
@@ -771,7 +771,7 @@ switch(FEAT_INDUSTRIES, SELF, chlor_alkali_plant_switch_location_check_industry_
 		(industry_distance(INDUSTRY_ID_DAIRY) >= 32) &&
 		(industry_distance(INDUSTRY_ID_SALT_MINE) >= 32) &&
 		(industry_distance(INDUSTRY_ID_CHLOR_ALKALI_PLANT) >= 16)
-		)]) {
+		))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/cleaning_products_factory.pnml
+++ b/src/industries/cleaning_products_factory.pnml
@@ -749,11 +749,11 @@ tilelayout cleaning_products_factory_tilelayout_4 {
 }
 
 switch(FEAT_INDUSTRIES, SELF, cleaning_products_factory_switch_location_check_industry_distance,
-	   (industry_distance(INDUSTRY_ID_SODA_PLANT) >= 32) &&
+	   (is_industry_funded_or_prospected()) || ((industry_distance(INDUSTRY_ID_SODA_PLANT) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_ACID_PLANT) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_PACKAGING_PLANT) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_CLEANING_PRODUCTS_FACTORY) >= 16) &&
-	   (town_euclidean_dist(0,0) > 32) // should not be near towns
+	   (town_euclidean_dist(0,0) > 32)) // should not be near towns
 	   ) 
 {
 	   1: return CB_RESULT_LOCATION_ALLOW;

--- a/src/industries/clothing_plant.pnml
+++ b/src/industries/clothing_plant.pnml
@@ -322,12 +322,12 @@ tilelayout clothing_plant_tilelayout_2 {
 switch(FEAT_INDUSTRIES, SELF, clothing_plant_switch_location_check_industry_distance,
        [STORE_TEMP(0, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(16, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 		(industry_distance(INDUSTRY_ID_CLOTHING_PLANT) >= 16) && 
 		(industry_distance(INDUSTRY_ID_DEPARTMENT_STORE) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PORT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PACKAGING_PLANT) != 32) &&
-	    (industry_distance(INDUSTRY_ID_TEXTILE_MILL) >= 32))]) {
+	    (industry_distance(INDUSTRY_ID_TEXTILE_MILL) >= 32)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/coal_liquefaction_plant.pnml
+++ b/src/industries/coal_liquefaction_plant.pnml
@@ -1110,7 +1110,7 @@ tilelayout coal_liquefaction_plant_tilelayout_5 {
 switch(FEAT_INDUSTRIES, SELF, coal_liquefaction_plant_switch_location_check_industry_distance,
        [STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_STEAMREFORMER) >= 32) && 
 		(industry_distance(INDUSTRY_ID_CHLOR_ALKALI_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_COAL_MINE) >= 32) && 
@@ -1118,7 +1118,7 @@ switch(FEAT_INDUSTRIES, SELF, coal_liquefaction_plant_switch_location_check_indu
 		(industry_distance(INDUSTRY_ID_PHARMACEUTICAL_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PLASTICS_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PETROL_STATION) >= 32) && 
-	    (industry_distance(INDUSTRY_ID_COAL_LIQUEFACTION_PLANT) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_COAL_LIQUEFACTION_PLANT) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/coal_mine.pnml
+++ b/src/industries/coal_mine.pnml
@@ -453,12 +453,12 @@ tilelayout coal_mine_industry_layout_6_tilelayout {
 }
 
 switch(FEAT_INDUSTRIES, SELF, coal_mine_switch_location_check_industry_distance,
-        (water_distance > 16) &&
+        (is_industry_funded_or_prospected()) || ((water_distance > 16) &&
 		(industry_distance(INDUSTRY_ID_COAL_MINE) >= 16) && 
 	    (industry_distance(INDUSTRY_ID_POWER_PLANT) >= 32) &&
 		(industry_distance(INDUSTRY_ID_INTEGRATED_STEEL_MILL) >= 32) &&
 		(industry_distance(INDUSTRY_ID_CARBON_BLACK_PLANT) >= 32) &&
-		(industry_distance(INDUSTRY_ID_BRICK_WORKS) >= 32)) 
+		(industry_distance(INDUSTRY_ID_BRICK_WORKS) >= 32))) 
 { 
 	1: return CB_RESULT_LOCATION_ALLOW;
 	return CB_RESULT_LOCATION_DISALLOW;

--- a/src/industries/coke_oven.pnml
+++ b/src/industries/coke_oven.pnml
@@ -2887,13 +2887,13 @@ tilelayout coke_oven_tilelayout_40 {
 switch(FEAT_INDUSTRIES, SELF, coke_oven_switch_location_check_industry_distance,
        [STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_COAL_MINE) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PORT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_INTEGRATED_STEEL_MILL) >= 32) && 
 		//(industry_distance(INDUSTRY_ID_ORE_SMELTER) >= 32) && 
 		//(industry_distance(INDUSTRY_ID_FOUNDRY) >= 32) && 
-	    (industry_distance(INDUSTRY_ID_COKE_OVEN) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_COKE_OVEN) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/copper_ore_mine.pnml
+++ b/src/industries/copper_ore_mine.pnml
@@ -373,9 +373,9 @@ tilelayout copper_ore_mine_industry_layout_1_tilelayout {
 }
 
 switch(FEAT_INDUSTRIES, SELF, copper_ore_mine_switch_location_check_industry_distance,
-        (water_distance > 16) &&
+        (is_industry_funded_or_prospected()) || ((water_distance > 16) &&
 		(industry_distance(INDUSTRY_ID_COPPER_ORE_MINE) >= 16) && 
-		(industry_distance(INDUSTRY_ID_COPPER_SMELTER) >= 32)) 
+		(industry_distance(INDUSTRY_ID_COPPER_SMELTER) >= 32))) 
 { 
 	1: return CB_RESULT_LOCATION_ALLOW;
 	return CB_RESULT_LOCATION_DISALLOW;

--- a/src/industries/copper_smelter.pnml
+++ b/src/industries/copper_smelter.pnml
@@ -995,14 +995,14 @@ tilelayout copper_smelter_tilelayout_3 {
 switch(FEAT_INDUSTRIES, SELF, copper_smelter_switch_location_check_industry_distance,
        [STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 		(industry_town_count(INDUSTRY_ID_POWER_PLANT) > 0) && // industry requires a power plant in the city
 		(industry_town_count(INDUSTRY_ID_COPPER_SMELTER) == 0) && // only allow one plant per city
 		(industry_distance(INDUSTRY_ID_COPPER_ORE_MINE) >= 32) && 
 		(industry_distance(INDUSTRY_ID_ACID_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_VEHICLE_FACTORY) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PAINT_FACTORY) >= 32) && 
-	    (industry_distance(INDUSTRY_ID_COPPER_SMELTER) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_COPPER_SMELTER) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/cryo_plant.pnml
+++ b/src/industries/cryo_plant.pnml
@@ -560,7 +560,7 @@ tilelayout cryo_plant_industry_layout_5_tilelayout {
 }
 
 switch(FEAT_INDUSTRIES, SELF, cryo_plant_switch_location_check_industry_distance,
-	   (industry_distance(INDUSTRY_ID_AMMONIA_PLANT) >= 32) &&
+	   (is_industry_funded_or_prospected()) || ((industry_distance(INDUSTRY_ID_AMMONIA_PLANT) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_ORE_SMELTER) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_CARBON_BLACK_PLANT) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_INTEGRATED_STEEL_MILL) >= 32) &&
@@ -568,7 +568,7 @@ switch(FEAT_INDUSTRIES, SELF, cryo_plant_switch_location_check_industry_distance
 	   (industry_distance(INDUSTRY_ID_ACID_PLANT) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_PHARMACEUTICAL_PLANT) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_CRYO_PLANT) >= 16) &&
-	   (town_euclidean_dist(0,0) > 32) // should not be near towns
+	   (town_euclidean_dist(0,0) > 32)) // should not be near towns
 	   ) 
 {
 	   1: return CB_RESULT_LOCATION_ALLOW;

--- a/src/industries/dairy.pnml
+++ b/src/industries/dairy.pnml
@@ -992,11 +992,11 @@ tilelayout dairy_tilelayout_6 {
 switch(FEAT_INDUSTRIES, SELF, dairy_switch_location_check_industry_distance,
        [STORE_TEMP(16, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(32, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_ANIMAL_FARM) >= 32) &&
 		(industry_distance(INDUSTRY_ID_CHLOR_ALKALI_PLANT) >= 32) &&
 	    (industry_distance(INDUSTRY_ID_GENERAL_STORE) >= 32) &&
-	    (industry_distance(INDUSTRY_ID_DAIRY) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_DAIRY) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/department_store.pnml
+++ b/src/industries/department_store.pnml
@@ -81,7 +81,7 @@ tilelayout department_store_tilelayout {
 }
 
 switch(FEAT_INDUSTRIES, SELF, department_store_switch_location_check_industry_distance,
-       [(
+       [(is_industry_funded_or_prospected()) || (
 	    (industry_distance(INDUSTRY_ID_FURNITURE_FACTORY) >= 32) &&
 		(industry_distance(INDUSTRY_ID_CLOTHING_PLANT) >= 32) &&
 	    (industry_distance(INDUSTRY_ID_GENERAL_STORE) >= 16) &&

--- a/src/industries/farm.pnml
+++ b/src/industries/farm.pnml
@@ -566,12 +566,12 @@ tilelayout farm_industry_layout_6_tilelayout {
 }
 
 switch(FEAT_INDUSTRIES, SELF, farm_switch_location_check_industry_distance,
-	   (industry_distance(INDUSTRY_ID_FARM) >= 16) &&
+	   (is_industry_funded_or_prospected()) || ((industry_distance(INDUSTRY_ID_FARM) >= 16) &&
 	   (industry_distance(INDUSTRY_ID_FOOD_PROCESSOR) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_BREWERY) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_ANIMAL_FARM) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_TEXTILE_MILL) >= 32) &&
-	   (town_euclidean_dist(0,0) > 32) // should not be near towns
+	   (town_euclidean_dist(0,0) > 32)) // should not be near towns
 	   ) 
 {
 	   1: return CB_RESULT_LOCATION_ALLOW;

--- a/src/industries/fishing_grounds.pnml
+++ b/src/industries/fishing_grounds.pnml
@@ -220,10 +220,10 @@ tilelayout fishing_grounds_industry_layout_4_tilelayout {
 }
 
 switch(FEAT_INDUSTRIES, SELF, fishing_grounds_switch_location_check_industry_distance,
-	   (industry_distance(INDUSTRY_ID_FISHING_GROUNDS) >= 16) 
+	   (is_industry_funded_or_prospected()) || ((industry_distance(INDUSTRY_ID_FISHING_GROUNDS) >= 16) 
 	   && is_near_map_edge(32)
-	   //&& (industry_distance(INDUSTRY_ID_FOOD_PROCESSOR) >= 32)
-	   ) 
+	   && (industry_distance(INDUSTRY_ID_FOOD_PROCESSOR) >= 32)
+	   ) )
 	   {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;

--- a/src/industries/flour_mill.pnml
+++ b/src/industries/flour_mill.pnml
@@ -988,11 +988,11 @@ tilelayout flour_mill_tilelayout_6 {
 switch(FEAT_INDUSTRIES, SELF, flour_mill_switch_location_check_industry_distance,
        [STORE_TEMP(0, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(24, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_FARM) >= 32) &&
 	    (industry_distance(INDUSTRY_ID_GENERAL_STORE) >= 32) &&
 		(industry_distance(INDUSTRY_ID_PACKAGING_PLANT) >= 32) &&
-	    (industry_distance(INDUSTRY_ID_FLOUR_MILL) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_FLOUR_MILL) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/food_processor.pnml
+++ b/src/industries/food_processor.pnml
@@ -390,7 +390,7 @@ tilelayout food_processor_industry_layout_3_tilelayout {
 switch(FEAT_INDUSTRIES, SELF, food_processor_switch_location_check_industry_distance,
        [STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_FARM) >= 32) && 
 		(industry_distance(INDUSTRY_ID_FISHING_GROUNDS) >= 32) && 
 		(industry_distance(INDUSTRY_ID_HOTEL) >= 32) && 
@@ -398,7 +398,7 @@ switch(FEAT_INDUSTRIES, SELF, food_processor_switch_location_check_industry_dist
 		(industry_distance(INDUSTRY_ID_CHLOR_ALKALI_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_SALT_MINE) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PACKAGING_PLANT) >= 32) && 
-	    (industry_distance(INDUSTRY_ID_FOOD_PROCESSOR) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_FOOD_PROCESSOR) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/forest.pnml
+++ b/src/industries/forest.pnml
@@ -4993,8 +4993,8 @@ tilelayout forest_layout_4_tilelayout {
 }
 
 switch(FEAT_INDUSTRIES, SELF, forest_switch_location_check_industry_distance,
-       (industry_distance(INDUSTRY_ID_FOREST) >= 16) 
-	   && (industry_distance(INDUSTRY_ID_SAWMILL) >= 32)
+       (is_industry_funded_or_prospected()) || ((industry_distance(INDUSTRY_ID_FOREST) >= 16) 
+	   && (industry_distance(INDUSTRY_ID_SAWMILL) >= 32))
 		) 
 {
 	   1: return CB_RESULT_LOCATION_ALLOW;

--- a/src/industries/fruit_plantation.pnml
+++ b/src/industries/fruit_plantation.pnml
@@ -2099,12 +2099,12 @@ tilelayout fruit_plantation_industry_layout_5_tilelayout {
 }
 
 switch(FEAT_INDUSTRIES, SELF, fruit_plantation_switch_location_check_industry_distance,
-	   (industry_distance(INDUSTRY_ID_GENERAL_STORE) >= 32) &&
+	   (is_industry_funded_or_prospected()) || ((industry_distance(INDUSTRY_ID_GENERAL_STORE) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_HOTEL) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_FOOD_PROCESSOR) >= 32) &&
 	   //(industry_distance(INDUSTRY_ID_BIOREFINERY) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_FRUIT_PLANTATION) >= 16) &&
-	   (town_euclidean_dist(0,0) > 32) // should not be near towns
+	   (town_euclidean_dist(0,0) > 32)) // should not be near towns
 	   ) 
 {
 	   1: return CB_RESULT_LOCATION_ALLOW;

--- a/src/industries/furniture_factory.pnml
+++ b/src/industries/furniture_factory.pnml
@@ -600,13 +600,13 @@ tilelayout furniture_factory_tilelayout_5 {
 switch(FEAT_INDUSTRIES, SELF, furniture_factory_switch_location_check_industry_distance,
 	[STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	 STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
         (industry_distance(INDUSTRY_ID_PLASTICS_PLANT) >= 32) && 
 	    (industry_distance(INDUSTRY_ID_SAWMILL) >= 32) && 
 		(industry_distance(INDUSTRY_ID_TEXTILE_MILL) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PORT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_DEPARTMENT_STORE) >= 32) && 
-	     (industry_distance(INDUSTRY_ID_FURNITURE_FACTORY) >= 16))]) {
+	     (industry_distance(INDUSTRY_ID_FURNITURE_FACTORY) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/general_store.pnml
+++ b/src/industries/general_store.pnml
@@ -109,7 +109,7 @@ tilelayout general_store_tilelayout {
 }
 
 switch(FEAT_INDUSTRIES, SELF, general_store_switch_location_check_industry_distance,
-       [(
+       [(is_industry_funded_or_prospected()) || (
 	    (industry_distance(INDUSTRY_ID_FOOD_PROCESSOR) >= 32) &&
 		(industry_distance(INDUSTRY_ID_BREWERY) >= 32) &&
 		(industry_distance(INDUSTRY_ID_DAIRY) >= 32) &&

--- a/src/industries/glass_works.pnml
+++ b/src/industries/glass_works.pnml
@@ -605,13 +605,13 @@ tilelayout glass_works_tilelayout_3 {
 switch(FEAT_INDUSTRIES, SELF, glass_works_switch_location_check_industry_distance,
        [STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_LIME_KILN) >= 32) && 
 		(industry_distance(INDUSTRY_ID_SANDPIT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_VEHICLE_FACTORY) >= 32) && 
 		(industry_distance(INDUSTRY_ID_BREWERY) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PACKAGING_PLANT) >= 32) && 
-	    (industry_distance(INDUSTRY_ID_GLASS_WORKS) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_GLASS_WORKS) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/hotel.pnml
+++ b/src/industries/hotel.pnml
@@ -377,7 +377,7 @@ tilelayout hotel_tilelayout_single_tile_2 {
 }
 
 switch(FEAT_INDUSTRIES, SELF, hotel_switch_location_check_industry_distance,
-       [(	    
+       [(is_industry_funded_or_prospected()) || (	    
 		(town_euclidean_dist(0,0) < 16) &&
 		(industry_distance(INDUSTRY_ID_GENERAL_STORE) >= 16) &&
 		(industry_distance(INDUSTRY_ID_OIL_RIG) >= 32) &&

--- a/src/industries/integrated_steel_mill.pnml
+++ b/src/industries/integrated_steel_mill.pnml
@@ -470,13 +470,13 @@ tilelayout steel_mill_tilelayout_2 {
 switch(FEAT_INDUSTRIES, SELF, steel_mill_switch_location_check_industry_distance,
        [STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_COAL_MINE) >= 32) && 
 		(industry_distance(INDUSTRY_ID_IRON_ORE_MINE) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PORT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_LIME_KILN) >= 32) && 
 		(industry_distance(INDUSTRY_ID_VEHICLE_FACTORY) >= 32) && 
-	    (industry_distance(INDUSTRY_ID_INTEGRATED_STEEL_MILL) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_INTEGRATED_STEEL_MILL) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/iron_ore_mine.pnml
+++ b/src/industries/iron_ore_mine.pnml
@@ -406,10 +406,10 @@ tilelayout iron_ore_mine_industry_layout_1_tilelayout {
 }
 
 switch(FEAT_INDUSTRIES, SELF, iron_ore_mine_switch_location_check_industry_distance,
-        (water_distance > 16) &&
+        (is_industry_funded_or_prospected()) || ((water_distance > 16) &&
 		(industry_distance(INDUSTRY_ID_IRON_ORE_MINE) >= 16) && 
 		(industry_distance(INDUSTRY_ID_PAINT_FACTORY) >= 16) && 
-		(industry_distance(INDUSTRY_ID_INTEGRATED_STEEL_MILL) >= 32)) 
+		(industry_distance(INDUSTRY_ID_INTEGRATED_STEEL_MILL) >= 32))) 
 { 
 	1: return CB_RESULT_LOCATION_ALLOW;
 	return CB_RESULT_LOCATION_DISALLOW;

--- a/src/industries/lime_kiln.pnml
+++ b/src/industries/lime_kiln.pnml
@@ -651,11 +651,11 @@ tilelayout lime_kiln_tilelayout_3 {
 switch(FEAT_INDUSTRIES, SELF, lime_kiln_switch_location_check_industry_distance,
        [STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_LIMESTONE_MINE) >= 32) && 
 		(industry_distance(INDUSTRY_ID_INTEGRATED_STEEL_MILL) >= 32) && 
 		(industry_distance(INDUSTRY_ID_GLASS_WORKS) >= 32) && 
-	    (industry_distance(INDUSTRY_ID_LIME_KILN) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_LIME_KILN) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/limestone_mine.pnml
+++ b/src/industries/limestone_mine.pnml
@@ -470,10 +470,10 @@ tilelayout limestone_mine_industry_layout_4_tilelayout {
 }
 
 switch(FEAT_INDUSTRIES, SELF, limestone_mine_switch_location_check_industry_distance,
-        (water_distance > 16) &&
+        (is_industry_funded_or_prospected()) || ((water_distance > 16) &&
 		(industry_distance(INDUSTRY_ID_LIMESTONE_MINE) >= 16) && 
 		(industry_distance(INDUSTRY_ID_PAINT_FACTORY) >= 32) && 
-		(industry_distance(INDUSTRY_ID_CEMENT_PLANT) >= 32)) 
+		(industry_distance(INDUSTRY_ID_CEMENT_PLANT) >= 32))) 
 { 
 	1: return CB_RESULT_LOCATION_ALLOW;
 	return CB_RESULT_LOCATION_DISALLOW;

--- a/src/industries/oil_refinery.pnml
+++ b/src/industries/oil_refinery.pnml
@@ -590,7 +590,7 @@ tilelayout oil_refinery_tilelayout_4 {
 switch(FEAT_INDUSTRIES, SELF, oil_refinery_switch_location_check_industry_distance,
 	[STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	 STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
         (industry_distance(INDUSTRY_ID_OIL_WELL) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PORT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_OIL_RIG) >= 32) && 
@@ -599,7 +599,7 @@ switch(FEAT_INDUSTRIES, SELF, oil_refinery_switch_location_check_industry_distan
 	    (industry_distance(INDUSTRY_ID_CARBON_BLACK_PLANT) >= 32) &&
 		(industry_distance(INDUSTRY_ID_PHARMACEUTICAL_PLANT) >= 32) &&
 		(industry_distance(INDUSTRY_ID_PETROL_STATION) >= 32) &&
-	    (industry_distance(INDUSTRY_ID_OIL_REFINERY) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_OIL_REFINERY) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/oil_rig.pnml
+++ b/src/industries/oil_rig.pnml
@@ -366,12 +366,12 @@ tilelayout oil_rig_layout_1_tilelayout {
 
 
 switch(FEAT_INDUSTRIES, SELF, oil_rig_switch_location_check_industry_distance,
-        (is_near_map_edge(32) && 
+        (is_industry_funded_or_prospected()) || ((is_near_map_edge(32) && 
 	    (industry_distance(INDUSTRY_ID_OIL_RIG) >= 16) && 
 	    (industry_distance(INDUSTRY_ID_PLASTICS_PLANT) >= 32) &&
 		(industry_distance(INDUSTRY_ID_CARBON_BLACK_PLANT) >= 32) &&
 		(industry_distance(INDUSTRY_ID_HOTEL) >= 32) &&
-		(industry_distance(INDUSTRY_ID_POWER_PLANT) >= 32)
+		(industry_distance(INDUSTRY_ID_POWER_PLANT) >= 32))
 		)) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;

--- a/src/industries/oil_well.pnml
+++ b/src/industries/oil_well.pnml
@@ -368,11 +368,11 @@ tilelayout oil_well_industry_layout_4_tilelayout {
 }
 
 switch(FEAT_INDUSTRIES, SELF, oil_well_switch_location_check_industry_distance,
-        (water_distance > 16) &&
+        (is_industry_funded_or_prospected()) || ((water_distance > 16) &&
 		(industry_distance(INDUSTRY_ID_OIL_WELL) >= 16) && 
 	    (industry_distance(INDUSTRY_ID_POWER_PLANT) >= 32) &&
 		(industry_distance(INDUSTRY_ID_CARBON_BLACK_PLANT) >= 32) &&
-		(industry_distance(INDUSTRY_ID_PLASTICS_PLANT) >= 32)) 
+		(industry_distance(INDUSTRY_ID_PLASTICS_PLANT) >= 32)) )
 { 
 	1: return CB_RESULT_LOCATION_ALLOW;
 	return CB_RESULT_LOCATION_DISALLOW;

--- a/src/industries/ore_smelter.pnml
+++ b/src/industries/ore_smelter.pnml
@@ -943,14 +943,14 @@ tilelayout ore_smelter_tilelayout_4 {
 switch(FEAT_INDUSTRIES, SELF, ore_smelter_switch_location_check_industry_distance,
        [STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_COPPER_ORE_MINE) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PORT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_INTEGRATED_STEEL_MILL) >= 32) && 
 		(industry_distance(INDUSTRY_ID_COPPER_SMELTER) >= 32) && 
 		(industry_distance(INDUSTRY_ID_COKE_OVEN) >= 32) && 
 		(industry_distance(INDUSTRY_ID_CRYO_PLANT) >= 32) && 
-	    (industry_distance(INDUSTRY_ID_ORE_SMELTER) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_ORE_SMELTER) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/packaging_plant.pnml
+++ b/src/industries/packaging_plant.pnml
@@ -571,7 +571,7 @@ tilelayout packaging_plant_industry_layout_3_tilelayout {
 switch(FEAT_INDUSTRIES, SELF, packaging_plant_switch_location_check_industry_distance,
        [STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_ALUMINIUM_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PLASTICS_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PHARMACEUTICAL_PLANT) >= 32) && 
@@ -584,7 +584,7 @@ switch(FEAT_INDUSTRIES, SELF, packaging_plant_switch_location_check_industry_dis
 		(industry_distance(INDUSTRY_ID_PAPER_MILL) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PRINTING_WORKS) >= 32) && 
 		(industry_distance(INDUSTRY_ID_GLASS_WORKS) >= 32) && 
-	    (industry_distance(INDUSTRY_ID_PACKAGING_PLANT) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_PACKAGING_PLANT) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/paint_factory.pnml
+++ b/src/industries/paint_factory.pnml
@@ -532,7 +532,7 @@ tilelayout paint_factory_tilelayout_2 {
 switch(FEAT_INDUSTRIES, SELF, paint_factory_switch_location_check_industry_distance,
 	[STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	 STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
         (industry_distance(INDUSTRY_ID_CARBON_BLACK_PLANT) >= 32) && 
 	    (industry_distance(INDUSTRY_ID_IRON_ORE_MINE) >= 32) && 
 		(industry_distance(INDUSTRY_ID_LIMESTONE_MINE) >= 32) && 
@@ -541,7 +541,7 @@ switch(FEAT_INDUSTRIES, SELF, paint_factory_switch_location_check_industry_dista
 		(industry_distance(INDUSTRY_ID_PLASTICS_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_VEHICLE_FACTORY) >= 32) && 
 		(industry_distance(INDUSTRY_ID_COPPER_SMELTER) >= 32) && 
-	    (industry_distance(INDUSTRY_ID_PAINT_FACTORY) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_PAINT_FACTORY) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/paper_mill.pnml
+++ b/src/industries/paper_mill.pnml
@@ -861,12 +861,12 @@ tilelayout paper_mill_tilelayout_4 {
 switch(FEAT_INDUSTRIES, SELF, paper_mill_switch_location_check_industry_distance,
        [STORE_TEMP(0, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(32, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 		(industry_distance(INDUSTRY_ID_PACKAGING_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PRINTING_WORKS) >= 32) && 
 		(industry_distance(INDUSTRY_ID_FOREST) >= 32) && 
 		(industry_distance(INDUSTRY_ID_CHLOR_ALKALI_PLANT) >= 32) && 
-	    (industry_distance(INDUSTRY_ID_PAPER_MILL) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_PAPER_MILL) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/petrol_station.pnml
+++ b/src/industries/petrol_station.pnml
@@ -147,7 +147,7 @@ tilelayout petrol_station_tilelayout_2 {
 }
 
 switch(FEAT_INDUSTRIES, SELF, petrol_station_switch_location_check_industry_distance,
-       [(
+       [(is_industry_funded_or_prospected()) || (
 	    (industry_distance(INDUSTRY_ID_COAL_LIQUEFACTION_PLANT) >= 32) &&
 		(industry_distance(INDUSTRY_ID_OIL_REFINERY) >= 32) &&
 		(industry_distance(INDUSTRY_ID_STEAMCRACKER) >= 32) &&

--- a/src/industries/pharmaceutical_plant.pnml
+++ b/src/industries/pharmaceutical_plant.pnml
@@ -761,11 +761,11 @@ tilelayout pharmaceutical_plant_industry_layout_6_tilelayout {
 switch(FEAT_INDUSTRIES, SELF, pharmaceutical_plant_switch_location_check_industry_distance,
        [STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_CHLOR_ALKALI_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PACKAGING_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_ACID_PLANT) >= 32) && 
-	    (industry_distance(INDUSTRY_ID_PHARMACEUTICAL_PLANT) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_PHARMACEUTICAL_PLANT) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/plastics_plant.pnml
+++ b/src/industries/plastics_plant.pnml
@@ -1042,7 +1042,7 @@ tilelayout plastics_plant_tilelayout_7 {
 switch(FEAT_INDUSTRIES, SELF, plastics_plant_switch_location_check_industry_distance,
 	[STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	 STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
         (industry_distance(INDUSTRY_ID_OIL_WELL) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PORT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_OIL_RIG) >= 32) && 
@@ -1050,7 +1050,7 @@ switch(FEAT_INDUSTRIES, SELF, plastics_plant_switch_location_check_industry_dist
 		(industry_distance(INDUSTRY_ID_FURNITURE_FACTORY) >= 32) && 
 		(industry_distance(INDUSTRY_ID_VEHICLE_FACTORY) >= 32) && 
 	    (industry_distance(INDUSTRY_ID_TEXTILE_MILL) >= 32) &&
-	    (industry_distance(INDUSTRY_ID_PLASTICS_PLANT) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_PLASTICS_PLANT) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/port.pnml
+++ b/src/industries/port.pnml
@@ -1352,7 +1352,7 @@ tilelayout port_tilelayout_5 {
 switch(FEAT_INDUSTRIES, SELF, port_switch_location_check_industry_distance,
     [STORE_TEMP(16, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	 STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	   (distance_from_town() && 
+	   (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 	   (is_near_map_edge(32)) &&
 	   (industry_distance(INDUSTRY_ID_ALUMINIUM_PLANT) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_BRICK_WORKS) >= 32) &&
@@ -1371,7 +1371,7 @@ switch(FEAT_INDUSTRIES, SELF, port_switch_location_check_industry_distance,
 	   (industry_distance(INDUSTRY_ID_PLASTICS_PLANT) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_POWER_PLANT) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_VEHICLE_FACTORY) >= 32) &&	   
-	   (industry_distance(INDUSTRY_ID_PORT) >= 16))])
+	   (industry_distance(INDUSTRY_ID_PORT) >= 16)))])
 {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;

--- a/src/industries/printing_works.pnml
+++ b/src/industries/printing_works.pnml
@@ -149,11 +149,11 @@ tilelayout printing_works_tilelayout_1 {
 switch(FEAT_INDUSTRIES, SELF, printing_works_switch_location_check_industry_distance,
        [STORE_TEMP(0, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(32, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_PAPER_MILL) >= 32) &&
 		(industry_distance(INDUSTRY_ID_DEPARTMENT_STORE) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PACKAGING_PLANT) >= 32) && 
-	    (industry_distance(INDUSTRY_ID_PRINTING_WORKS) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_PRINTING_WORKS) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/salt_mine.pnml
+++ b/src/industries/salt_mine.pnml
@@ -524,10 +524,10 @@ tilelayout salt_mine_industry_layout_4_tilelayout {
 }
 
 switch(FEAT_INDUSTRIES, SELF, salt_mine_switch_location_check_industry_distance,
-        (water_distance > 16) &&
+        (is_industry_funded_or_prospected()) || ((water_distance > 16) &&
 		(industry_distance(INDUSTRY_ID_SALT_MINE) >= 16) && 
 		(industry_distance(INDUSTRY_ID_FOOD_PROCESSOR) >= 32) && 
-		(industry_distance(INDUSTRY_ID_CHLOR_ALKALI_PLANT) >= 32)) 
+		(industry_distance(INDUSTRY_ID_CHLOR_ALKALI_PLANT) >= 32))) 
 { 
 	1: return CB_RESULT_LOCATION_ALLOW;
 	return CB_RESULT_LOCATION_DISALLOW;

--- a/src/industries/sandpit.pnml
+++ b/src/industries/sandpit.pnml
@@ -1130,10 +1130,10 @@ tilelayout sandpit_layout_2_tilelayout {
 }
 
 switch(FEAT_INDUSTRIES, SELF, sandpit_switch_location_check_industry_distance,
-		(industry_distance(INDUSTRY_ID_SANDPIT) >= 16) && 
+		(is_industry_funded_or_prospected()) || ((industry_distance(INDUSTRY_ID_SANDPIT) >= 16) && 
 		(industry_distance(INDUSTRY_ID_CEMENT_PLANT) >= 32) &&
 		(industry_distance(INDUSTRY_ID_GLASS_WORKS) >= 32) &&
-		(industry_distance(INDUSTRY_ID_BUILDERS_YARD) >= 32)
+		(industry_distance(INDUSTRY_ID_BUILDERS_YARD) >= 32))
 		) 
 { 
 	1: return CB_RESULT_LOCATION_ALLOW;

--- a/src/industries/sawmill.pnml
+++ b/src/industries/sawmill.pnml
@@ -419,11 +419,11 @@ tilelayout sawmill_tilelayout_1 {
 switch(FEAT_INDUSTRIES, SELF, sawmill_switch_location_check_industry_distance,
        [STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_FOREST) >= 32) &&
 	    (industry_distance(INDUSTRY_ID_FURNITURE_FACTORY) >= 32) &&
 		(industry_distance(INDUSTRY_ID_BUILDERS_YARD) >= 32) && 
-	    (industry_distance(INDUSTRY_ID_SAWMILL) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_SAWMILL) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/soda_plant.pnml
+++ b/src/industries/soda_plant.pnml
@@ -451,11 +451,11 @@ tilelayout soda_plant_tilelayout_3 {
 }
 
 switch(FEAT_INDUSTRIES, SELF, soda_plant_switch_location_check_industry_distance,
-	   (industry_distance(INDUSTRY_ID_AMMONIA_PLANT) >= 32) &&
+	   (is_industry_funded_or_prospected()) || ((industry_distance(INDUSTRY_ID_AMMONIA_PLANT) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_GLASS_WORKS) >= 32) &&
-	   //(industry_distance(INDUSTRY_ID_CLEANING_AGENTS_PLANT) >= 32) &&
+	   (industry_distance(INDUSTRY_TILE_ID_CLEANING_PRODUCTS_FACTORY) >= 32) &&
 	   (industry_distance(INDUSTRY_ID_SODA_PLANT) >= 16) &&
-	   (town_euclidean_dist(0,0) > 32) // should not be near towns
+	   (town_euclidean_dist(0,0) > 32)) // should not be near towns
 	   ) 
 {
 	   1: return CB_RESULT_LOCATION_ALLOW;

--- a/src/industries/steamcracker.pnml
+++ b/src/industries/steamcracker.pnml
@@ -880,12 +880,12 @@ tilelayout steamcracker_tilelayout_6 {
 switch(FEAT_INDUSTRIES, SELF, steamcracker_switch_location_check_industry_distance,
        [STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_PLASTICS_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PHARMACEUTICAL_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PETROL_STATION) >= 32) && 
 		(industry_distance(INDUSTRY_ID_OIL_REFINERY) >= 32) && 
-	    (industry_distance(INDUSTRY_ID_STEAMCRACKER) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_STEAMCRACKER) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/steamreformer.pnml
+++ b/src/industries/steamreformer.pnml
@@ -1071,11 +1071,11 @@ tilelayout steamreformer_tilelayout_7 {
 switch(FEAT_INDUSTRIES, SELF, steamreformer_switch_location_check_industry_distance,
        [STORE_TEMP(32, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(64, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 		(industry_distance(INDUSTRY_ID_PHARMACEUTICAL_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_COAL_LIQUEFACTION_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_OIL_REFINERY) >= 32) && 
-	    (industry_distance(INDUSTRY_ID_STEAMREFORMER) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_STEAMREFORMER) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/stockyard.pnml
+++ b/src/industries/stockyard.pnml
@@ -1136,11 +1136,11 @@ tilelayout stockyard_tilelayout_1 {
 switch(FEAT_INDUSTRIES, SELF, stockyard_switch_location_check_industry_distance,
        [STORE_TEMP(0, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(24, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_ANIMAL_FARM) >= 32) &&
 	    (industry_distance(INDUSTRY_ID_GENERAL_STORE) >= 32) &&
 		(industry_distance(INDUSTRY_ID_HOTEL) >= 32) &&
-	    (industry_distance(INDUSTRY_ID_STOCKYARD) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_STOCKYARD) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/textile_mill.pnml
+++ b/src/industries/textile_mill.pnml
@@ -654,13 +654,13 @@ tilelayout textile_mill_tilelayout_6 {
 switch(FEAT_INDUSTRIES, SELF, textile_mill_switch_location_check_industry_distance,
        [STORE_TEMP(0, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(16, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || ((distance_from_town() && 
 	    (industry_distance(INDUSTRY_ID_FARM) >= 32) && 
 		(industry_distance(INDUSTRY_ID_CLOTHING_PLANT) >= 32) && 
 		(industry_distance(INDUSTRY_ID_PLASTICS_PLANT) >= 32) &&
 		(industry_distance(INDUSTRY_ID_PAINT_FACTORY) >= 32) &&
 		(industry_distance(INDUSTRY_ID_FURNITURE_FACTORY) >= 32) &&
-	    (industry_distance(INDUSTRY_ID_TEXTILE_MILL) >= 16))]) {
+	    (industry_distance(INDUSTRY_ID_TEXTILE_MILL) >= 16)))]) {
 	   1: return CB_RESULT_LOCATION_ALLOW;
 	   return CB_RESULT_LOCATION_DISALLOW;
 }

--- a/src/industries/vehicle_distributor.pnml
+++ b/src/industries/vehicle_distributor.pnml
@@ -236,7 +236,7 @@ tilelayout vehicle_distributor_tilelayout_3 {
 }
 
 switch(FEAT_INDUSTRIES, SELF, vehicle_distributor_switch_location_check_industry_distance,
-       [(
+       [(is_industry_funded_or_prospected()) || (
 	    (town_euclidean_dist(0,0) < 16) &&
 	    (industry_distance(INDUSTRY_ID_VEHICLE_FACTORY) >= 32) &&
 		(industry_distance(INDUSTRY_ID_VEHICLE_DISTRIBUTOR) >= 16))]) {

--- a/src/industries/vehicle_factory.pnml
+++ b/src/industries/vehicle_factory.pnml
@@ -588,7 +588,7 @@ tilelayout vehicle_factory_tilelayout_4 {
 switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_location_check_industry_distance,
        [STORE_TEMP(24, TEMP_REGISTER_TOWN_MIN_DISTANCE),
 	    STORE_TEMP(128, TEMP_REGISTER_TOWN_MAX_DISTANCE),
-	    (distance_from_town() && 
+	    (is_industry_funded_or_prospected()) || (distance_from_town() && 
 		(industry_town_count(INDUSTRY_ID_POWER_PLANT) > 0) && // industry requires a power plant in the city
 		(industry_town_count(INDUSTRY_ID_VEHICLE_FACTORY) == 0) && // only allow one factory per city
 		(industry_distance(INDUSTRY_ID_INTEGRATED_STEEL_MILL) >= 32) &&


### PR DESCRIPTION
This changeset fixes the problem that industries placed by prospecting/funding still had to follow the location checks. This made it somewhat impossible to place industries in the scenario editor.