### PR TITLE
fix: parameter to forbid industry generation was broken

### DIFF
--- a/src/industries/acid_plant.pnml
+++ b/src/industries/acid_plant.pnml
@@ -1109,7 +1109,7 @@ switch(FEAT_INDUSTRIES, SELF, acid_plant_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, acid_plant_switch_check_availability, 
 	current_year) {
 	0..1799: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 if (param_extension_coke_sulphur && !param_extension_basic_inorganic_chemistry && !param_extension_ammonia) {

--- a/src/industries/aluminium_plant.pnml
+++ b/src/industries/aluminium_plant.pnml
@@ -1376,7 +1376,7 @@ switch(FEAT_INDUSTRIES, SELF, aluminium_plant_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, aluminium_plant_switch_check_availability, 
 	current_year) {
 	0..1899: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, aluminium_plant_switch_cargo_subtype, getbits(extra_callback_info2, 16, 8)) {

--- a/src/industries/ammonia_plant.pnml
+++ b/src/industries/ammonia_plant.pnml
@@ -1105,7 +1105,7 @@ switch(FEAT_INDUSTRIES, SELF, ammonia_plant_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, ammonia_plant_switch_check_availability, 
 	current_year) {
 	0..1909: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, ammonia_plant_switch_update_last_served_date,

--- a/src/industries/animal_farm.pnml
+++ b/src/industries/animal_farm.pnml
@@ -468,7 +468,7 @@ if (param_extension_food_industries && !param_extension_textile_industries && !p
 		}
 	
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        animal_farm_switch_produce;
 			monthly_prod_change:      animal_farm_switch_update_last_served_date;
@@ -505,7 +505,7 @@ if (param_extension_food_industries && param_extension_textile_industries && !pa
 		}
 	
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        animal_farm_switch_produce_ext_textile_industries;
 			monthly_prod_change:      animal_farm_switch_update_last_served_date_ext_textile_industries;
@@ -542,7 +542,7 @@ if (param_extension_food_industries && !param_extension_textile_industries && pa
 		}
 	
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        animal_farm_switch_produce_ext_fruits;
 			monthly_prod_change:      animal_farm_switch_update_last_served_date;
@@ -579,7 +579,7 @@ if (param_extension_food_industries && param_extension_textile_industries && par
 		}
 	
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        animal_farm_switch_produce_ext_textile_industries_ext_fruits;
 			monthly_prod_change:      animal_farm_switch_update_last_served_date_ext_textile_industries;

--- a/src/industries/biorefinery.pnml
+++ b/src/industries/biorefinery.pnml
@@ -1035,7 +1035,7 @@ switch(FEAT_INDUSTRIES, SELF, biorefinery_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, biorefinery_switch_check_availability, 
 	current_year) {
 	0..1899: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, biorefinery_switch_update_last_served_date,

--- a/src/industries/brewery.pnml
+++ b/src/industries/brewery.pnml
@@ -535,6 +535,7 @@ if (param_extension_food_industries && !param_extension_glass) {
 		}
 			
 		graphics {
+		    construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        brewery_switch_produce;
 			monthly_prod_change:      brewery_switch_update_last_served_date;
@@ -568,6 +569,7 @@ if (param_extension_food_industries && param_extension_glass) {
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        brewery_switch_produce_ext_glass;
 			monthly_prod_change:      brewery_switch_update_last_served_date_ext_glass;

--- a/src/industries/brick_works.pnml
+++ b/src/industries/brick_works.pnml
@@ -574,7 +574,7 @@ switch(FEAT_INDUSTRIES, SELF, brick_works_switch_extra_text_fund,
 // year < 1800: no creation
 switch(FEAT_INDUSTRIES, SELF, brick_works_switch_check_availability, current_year) {
 	0..1799: return CB_RESULT_IND_NO_CONSTRUCTION;               // no coal mines before 1800
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 // only show stockpile for COAL and nothing else

--- a/src/industries/builders_yard.pnml
+++ b/src/industries/builders_yard.pnml
@@ -370,7 +370,7 @@ if (param_extension_building_materials) {
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_BUILDERS_YARD));
 		}
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        builders_yard_switch_produce_extension_building_industry;
 			monthly_prod_change:      builders_yard_switch_update_last_served_date;
@@ -406,7 +406,7 @@ if (!param_extension_building_materials) {
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_BUILDERS_YARD));
 		}
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        builders_yard_switch_produce;
 			monthly_prod_change:      builders_yard_switch_update_last_served_date_extension_building_industry;

--- a/src/industries/carbon_black_plant.pnml
+++ b/src/industries/carbon_black_plant.pnml
@@ -630,7 +630,7 @@ switch(FEAT_INDUSTRIES, SELF, carbon_black_plant_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, carbon_black_plant_switch_check_availability, 
 	current_year) {
 	0..1849: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, carbon_black_plant_switch_update_last_served_date,

--- a/src/industries/cement_plant.pnml
+++ b/src/industries/cement_plant.pnml
@@ -1006,7 +1006,7 @@ switch(FEAT_INDUSTRIES, SELF, cement_plant_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, cement_plant_switch_check_availability, 
 	current_year) {
 	0..1799: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, cement_plant_switch_update_last_served_date,

--- a/src/industries/chlor_alkali_plant.pnml
+++ b/src/industries/chlor_alkali_plant.pnml
@@ -867,7 +867,7 @@ switch(FEAT_INDUSTRIES, SELF, chlor_alkali_plant_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, chlor_alkali_plant_switch_check_availability, 
 	current_year) {
 	0..1899: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 // only show stockpile for STEL, PLAS and nothing else

--- a/src/industries/cleaning_products_factory.pnml
+++ b/src/industries/cleaning_products_factory.pnml
@@ -879,7 +879,7 @@ switch(FEAT_INDUSTRIES, SELF, cleaning_products_factory_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, cleaning_products_factory_switch_check_availability, 
 	current_year) {
 	0..1859: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, cleaning_products_factory_switch_update_last_served_date,

--- a/src/industries/clothing_plant.pnml
+++ b/src/industries/clothing_plant.pnml
@@ -424,7 +424,7 @@ if (param_extension_textile_industries) {
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        clothing_plant_switch_produce;
 			monthly_prod_change:      clothing_plant_switch_update_last_served_date;
@@ -459,7 +459,7 @@ if (param_extension_textile_industries && param_extension_packaging_industries) 
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        clothing_plant_switch_produce_ext_packaging_industries;
 			monthly_prod_change:      clothing_plant_switch_update_last_served_date_ext_packaging_industries;

--- a/src/industries/coal_liquefaction_plant.pnml
+++ b/src/industries/coal_liquefaction_plant.pnml
@@ -1163,7 +1163,7 @@ switch(FEAT_INDUSTRIES, SELF, coal_liquefaction_plant_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, coal_liquefaction_plant_switch_check_availability, 
 	current_year) {
 	0..1929: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, coal_liquefaction_plant_switch_update_last_served_date,

--- a/src/industries/coal_mine.pnml
+++ b/src/industries/coal_mine.pnml
@@ -546,7 +546,7 @@ switch(FEAT_INDUSTRIES, SELF, coal_mine_switch_check_availability_map_gen,
 switch(FEAT_INDUSTRIES, SELF, coal_mine_switch_check_availability, current_year) {
 	0..1799: return CB_RESULT_IND_NO_CONSTRUCTION;               // no coal mines before 1800
 	1950..5000000: coal_mine_switch_check_availability_map_gen;  // check mode, if the map is generated with that starting year, coal mines should exist
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 item(FEAT_INDUSTRIES, coal_mine, INDUSTRY_ID_COAL_MINE) {

--- a/src/industries/coke_oven.pnml
+++ b/src/industries/coke_oven.pnml
@@ -2945,7 +2945,7 @@ switch(FEAT_INDUSTRIES, SELF, coke_oven_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, coke_oven_switch_check_availability, 
 	current_year) {
 	0..1799: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 if (param_extension_coke_sulphur) {

--- a/src/industries/copper_ore_mine.pnml
+++ b/src/industries/copper_ore_mine.pnml
@@ -484,7 +484,7 @@ switch(FEAT_INDUSTRIES, SELF, copper_ore_mine_switch_check_availability_map_gen,
 switch(FEAT_INDUSTRIES, SELF, copper_ore_mine_switch_check_availability, current_year) {
 	0..1799: return CB_RESULT_IND_NO_CONSTRUCTION;               // no copper ore mines before 1800
 	1930..5000000: copper_ore_mine_switch_check_availability_map_gen;  // check mode, if the map is generated with that starting year, copper ore mines should exist
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 if (param_extension_painting_industries && !param_extension_coke_sulphur) {

--- a/src/industries/copper_smelter.pnml
+++ b/src/industries/copper_smelter.pnml
@@ -1161,7 +1161,7 @@ switch(FEAT_INDUSTRIES, SELF, copper_smelter_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, copper_smelter_switch_check_availability, 
 	current_year) {
 	0..1899: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, copper_smelter_switch_cargo_subtype, getbits(extra_callback_info2, 16, 8)) {

--- a/src/industries/cryo_plant.pnml
+++ b/src/industries/cryo_plant.pnml
@@ -634,7 +634,7 @@ switch(FEAT_INDUSTRIES, SELF, cryo_plant_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, cryo_plant_switch_check_availability, 
 	current_year) {
 	0..1899: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 if (param_extension_ammonia) {

--- a/src/industries/dairy.pnml
+++ b/src/industries/dairy.pnml
@@ -1176,6 +1176,7 @@ if (param_extension_food_industries && !param_extension_basic_inorganic_chemistr
 		}
 			
 		graphics {
+		    construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        dairy_switch_produce;
 			monthly_prod_change:      dairy_switch_update_last_served_date;
@@ -1209,6 +1210,7 @@ if (param_extension_food_industries && param_extension_basic_inorganic_chemistry
 		}
 			
 		graphics {
+		    construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        dairy_switch_produce_ext_basic_inorganic_chemistry;
 			monthly_prod_change:      dairy_switch_update_last_served_date_ext_basic_inorganic_chemistry;
@@ -1243,6 +1245,7 @@ if (param_extension_food_industries && !param_extension_basic_inorganic_chemistr
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        dairy_switch_produce_ext_packaging_industries;
 			monthly_prod_change:      dairy_switch_update_last_served_date_ext_packaging_industries;
@@ -1277,6 +1280,7 @@ if (param_extension_food_industries && param_extension_basic_inorganic_chemistry
 		}
 			
 		graphics {
+		    construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        dairy_switch_produce_ext_basic_inorganic_chemistry_ext_packaging_industries;
 			monthly_prod_change:      dairy_switch_update_last_served_date_ext_basic_inorganic_chemistry_ext_packaging_industries;

--- a/src/industries/department_store.pnml
+++ b/src/industries/department_store.pnml
@@ -132,7 +132,7 @@ item(FEAT_INDUSTRIES, department_store, INDUSTRY_ID_DEPARTMENT_STORE) {
 	}
         
 	graphics {
-		construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+		construction_probability: get_construction_probability;
 		produce_cargo_arrival:    empty_produce; 
 		produce_256_ticks:        department_store_switch_produce;
 		monthly_prod_change:      department_store_switch_update_last_served_date;

--- a/src/industries/farm.pnml
+++ b/src/industries/farm.pnml
@@ -708,7 +708,7 @@ if (param_extension_textile_industries && !param_extension_food_industries && !p
 		}
 	
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        farm_switch_produce_extension_textile_industry;
 			monthly_prod_change:      farm_switch_prod_change;
@@ -744,7 +744,7 @@ if (!param_extension_textile_industries && !param_extension_food_industries && !
 		}
 	
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        farm_switch_produce;
 			monthly_prod_change:      farm_switch_prod_change;
@@ -780,7 +780,7 @@ if (param_extension_food_industries && !param_extension_fruits) {
 		}
 	
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        farm_switch_produce_extension_food_industry;
 			monthly_prod_change:      farm_switch_prod_change;
@@ -816,7 +816,7 @@ if (param_extension_textile_industries && !param_extension_food_industries && pa
 		}
 	
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        farm_switch_produce_extension_textile_industry_ext_fruits;
 			monthly_prod_change:      farm_switch_prod_change;
@@ -852,7 +852,7 @@ if (!param_extension_textile_industries && !param_extension_food_industries && p
 		}
 	
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        farm_switch_produce_ext_fruits;
 			monthly_prod_change:      farm_switch_prod_change;
@@ -888,7 +888,7 @@ if (param_extension_food_industries && param_extension_fruits) {
 		}
 	
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        farm_switch_produce_extension_food_industry_ext_fruits;
 			monthly_prod_change:      farm_switch_prod_change;

--- a/src/industries/fishing_grounds.pnml
+++ b/src/industries/fishing_grounds.pnml
@@ -296,7 +296,7 @@ item(FEAT_INDUSTRIES, fishing_grounds, INDUSTRY_ID_FISHING_GROUNDS) {
 	}
 
 	graphics {
-		construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+		construction_probability: get_construction_probability;
 		produce_cargo_arrival:    empty_produce; 
 		produce_256_ticks:        fishing_grounds_switch_produce;
 		monthly_prod_change:      fishing_grounds_switch_prod_change;

--- a/src/industries/flour_mill.pnml
+++ b/src/industries/flour_mill.pnml
@@ -1090,6 +1090,7 @@ if (param_extension_food_industries && !param_extension_packaging_industries) {
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        flour_mill_switch_produce;
 			monthly_prod_change:      flour_mill_switch_update_last_served_date;
@@ -1123,6 +1124,7 @@ if (param_extension_food_industries && param_extension_packaging_industries) {
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        flour_mill_switch_produce_ext_packaging_industries;
 			monthly_prod_change:      flour_mill_switch_update_last_served_date_ext_packaging_industries;

--- a/src/industries/food_processor.pnml
+++ b/src/industries/food_processor.pnml
@@ -1022,6 +1022,7 @@ if (!param_extension_basic_inorganic_chemistry && !param_extension_food_industri
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        food_processor_switch_produce;
 			monthly_prod_change:      food_processor_switch_update_last_served_date;
@@ -1056,6 +1057,7 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_food_industrie
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        food_processor_switch_produce_ext_basic_inorganic_chemistry;
 			monthly_prod_change:      food_processor_switch_update_last_served_date_ext_basic_inorganic_chemistry;
@@ -1090,6 +1092,7 @@ if (!param_extension_basic_inorganic_chemistry && param_extension_food_industrie
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        food_processor_switch_produce_ext_food_industries;
 			monthly_prod_change:      food_processor_switch_update_last_served_date_ext_food_industries;
@@ -1124,6 +1127,7 @@ if (param_extension_basic_inorganic_chemistry && param_extension_food_industries
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        food_processor_switch_produce_ext_food_industries_ext_basic_inorganic_chemistry;
 			monthly_prod_change:      food_processor_switch_update_last_served_date_ext_food_industries_ext_basic_inorganic_chemistry;
@@ -1158,6 +1162,7 @@ if (!param_extension_basic_inorganic_chemistry && !param_extension_food_industri
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        food_processor_switch_produce_ext_packaging_industries;
 			monthly_prod_change:      food_processor_switch_update_last_served_date_ext_packaging_industries;
@@ -1192,6 +1197,7 @@ if (!param_extension_basic_inorganic_chemistry && param_extension_food_industrie
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        food_processor_switch_produce_ext_food_industries_ext_packaging_industries;
 			monthly_prod_change:      food_processor_switch_update_last_served_date_ext_food_industries_ext_packaging_industries;
@@ -1226,6 +1232,7 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_food_industrie
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        food_processor_switch_produce_ext_basic_inorganic_chemistry_ext_packaging_industries;
 			monthly_prod_change:      food_processor_switch_update_last_served_date_ext_basic_inorganic_chemistry_ext_packaging_industries;
@@ -1259,6 +1266,7 @@ if (param_extension_basic_inorganic_chemistry && param_extension_food_industries
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        food_processor_switch_produce_ext_basic_inorganic_chemistry_ext_food_industries_ext_packaging_industries;
 			monthly_prod_change:      food_processor_switch_update_last_served_date_ext_basic_inorganic_chemistry_ext_food_industries_ext_packaging_industries;
@@ -1293,6 +1301,7 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_food_industrie
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        food_processor_switch_produce_ext_basic_inorganic_chemistry_ext_fruits;
 			monthly_prod_change:      food_processor_switch_update_last_served_date_ext_basic_inorganic_chemistry_ext_fruits;
@@ -1327,6 +1336,7 @@ if (param_extension_basic_inorganic_chemistry && param_extension_food_industries
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        food_processor_switch_produce_ext_food_industries_ext_basic_inorganic_chemistry_ext_fruits;
 			monthly_prod_change:      food_processor_switch_update_last_served_date_ext_food_industries_ext_basic_inorganic_chemistry_ext_fruits;
@@ -1361,6 +1371,7 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_food_industrie
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        food_processor_switch_produce_ext_basic_inorganic_chemistry_ext_packaging_industries_ext_fruits;
 			monthly_prod_change:      food_processor_switch_update_last_served_date_ext_basic_inorganic_chemistry_ext_packaging_industries_ext_fruits;
@@ -1394,6 +1405,7 @@ if (param_extension_basic_inorganic_chemistry && param_extension_food_industries
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        food_processor_switch_produce_ext_basic_inorganic_chemistry_ext_food_industries_ext_packaging_industries_ext_fruits;
 			monthly_prod_change:      food_processor_switch_update_last_served_date_ext_basic_inorganic_chemistry_ext_food_industries_ext_packaging_industries_ext_fruits;

--- a/src/industries/forest.pnml
+++ b/src/industries/forest.pnml
@@ -5072,7 +5072,7 @@ item(FEAT_INDUSTRIES, forest, INDUSTRY_ID_FOREST) {
 	}
 
 	graphics {
-		construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+		construction_probability: get_construction_probability;
 		produce_cargo_arrival:    empty_produce; 
 		produce_256_ticks:        forest_switch_produce;
 		monthly_prod_change:      forest_switch_prod_change;

--- a/src/industries/fruit_plantation.pnml
+++ b/src/industries/fruit_plantation.pnml
@@ -2186,7 +2186,7 @@ if (param_extension_fruits) {
 		}
 	
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        fruit_plantation_switch_produce;
 			monthly_prod_change:      fruit_plantation_switch_prod_change;

--- a/src/industries/furniture_factory.pnml
+++ b/src/industries/furniture_factory.pnml
@@ -813,7 +813,7 @@ if (param_extension_textile_industries && !param_extension_packaging_industries)
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        furniture_factory_switch_produce_extension_textile_industry;
 			monthly_prod_change:      furniture_factory_switch_update_last_served_date_ext_textile_industries;
@@ -849,7 +849,7 @@ if (!param_extension_textile_industries && !param_extension_packaging_industries
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        furniture_factory_switch_produce;
 			monthly_prod_change:      furnitury_factory_switch_update_last_served_date;
@@ -885,7 +885,7 @@ if (param_extension_textile_industries && param_extension_packaging_industries) 
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        furniture_factory_switch_produce_extension_textile_industry_ext_packaging_industries;
 			monthly_prod_change:      furniture_factory_switch_update_last_served_date_ext_textile_industries_ext_packaging_industries;
@@ -921,7 +921,7 @@ if (!param_extension_textile_industries && param_extension_packaging_industries)
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        furniture_factory_switch_produce_ext_packaging_industries;
 			monthly_prod_change:      furnitury_factory_switch_update_last_served_date_ext_packaging_industries;

--- a/src/industries/general_store.pnml
+++ b/src/industries/general_store.pnml
@@ -185,7 +185,7 @@ if (!param_extension_fruits) {
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        general_store_switch_produce;
 			monthly_prod_change:      CB_RESULT_IND_PROD_NO_CHANGE;
@@ -222,7 +222,7 @@ if (param_extension_fruits) {
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        general_store_switch_produce_extension_fruits;
 			monthly_prod_change:      CB_RESULT_IND_PROD_NO_CHANGE;

--- a/src/industries/glass_works.pnml
+++ b/src/industries/glass_works.pnml
@@ -707,7 +707,7 @@ if (param_extension_glass && !param_extension_ammonia) {
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        glass_works_switch_produce;
 			monthly_prod_change:      glass_works_switch_update_last_served_date;
@@ -742,7 +742,7 @@ if (param_extension_glass && param_extension_ammonia) {
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        glass_works_switch_produce_ext_ammonia;
 			monthly_prod_change:      glass_works_switch_update_last_served_date_ext_ammonia;

--- a/src/industries/hotel.pnml
+++ b/src/industries/hotel.pnml
@@ -462,7 +462,7 @@ if (!param_extension_fruits) {
 		}
 
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        hotel_switch_produce;
 			monthly_prod_change:      hotel_switch_update_last_served_date;
@@ -499,7 +499,7 @@ if (param_extension_fruits) {
 		}
 
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        hotel_switch_produce_ext_fruits;
 			monthly_prod_change:      hotel_switch_update_last_served_date_ext_fruits;

--- a/src/industries/integrated_steel_mill.pnml
+++ b/src/industries/integrated_steel_mill.pnml
@@ -718,7 +718,7 @@ switch(FEAT_INDUSTRIES, SELF, steel_mill_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, steel_mill_switch_check_availability, 
 	current_year) {
 	0..1799: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, steel_mill_switch_cargo_subtype, getbits(extra_callback_info2, 16, 8)) {

--- a/src/industries/iron_ore_mine.pnml
+++ b/src/industries/iron_ore_mine.pnml
@@ -497,7 +497,7 @@ switch(FEAT_INDUSTRIES, SELF, iron_ore_mine_switch_check_availability_map_gen,
 switch(FEAT_INDUSTRIES, SELF, iron_ore_mine_switch_check_availability, current_year) {
 	0..1799: return CB_RESULT_IND_NO_CONSTRUCTION;               // no iron ore mines before 1800
 	1930..5000000: iron_ore_mine_switch_check_availability_map_gen;  // check mode, if the map is generated with that starting year, iron ore mines should exist
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 item(FEAT_INDUSTRIES, iron_ore_mine, INDUSTRY_ID_IRON_ORE_MINE) {

--- a/src/industries/lime_kiln.pnml
+++ b/src/industries/lime_kiln.pnml
@@ -754,7 +754,7 @@ if (param_extension_glass && !param_extension_coke_sulphur) {
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        lime_kiln_switch_produce;
 			monthly_prod_change:      lime_kiln_switch_update_last_served_date;
@@ -789,7 +789,7 @@ if (param_extension_glass && param_extension_coke_sulphur) {
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        lime_kiln_switch_produce_ext_coke_sulphur;
 			monthly_prod_change:      lime_kiln_switch_update_last_served_date_ext_coke_sulphur;

--- a/src/industries/limestone_mine.pnml
+++ b/src/industries/limestone_mine.pnml
@@ -547,7 +547,7 @@ switch(FEAT_INDUSTRIES, SELF, limestone_mine_switch_extra_text_fund,
 // year < 1800: no creation
 switch(FEAT_INDUSTRIES, SELF, limestone_mine_switch_check_availability, current_year) {
 	0..1799: return CB_RESULT_IND_NO_CONSTRUCTION;               // no limestone mines before 1800
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 if (param_extension_building_materials) {

--- a/src/industries/oil_refinery.pnml
+++ b/src/industries/oil_refinery.pnml
@@ -654,7 +654,7 @@ switch(FEAT_INDUSTRIES, SELF, oil_refinery_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, oil_refinery_switch_check_availability, 
 	current_year) {
 	0..1859: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, oil_refinery_switch_cargo_subtype, getbits(extra_callback_info2, 16, 8)) {

--- a/src/industries/oil_rig.pnml
+++ b/src/industries/oil_rig.pnml
@@ -442,7 +442,7 @@ switch(FEAT_INDUSTRIES, SELF, oil_rig_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, oil_rig_switch_check_availability, 
 	current_year) {
 	0..1984: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 item(FEAT_INDUSTRIES, oil_rig, INDUSTRY_ID_OIL_RIG) {

--- a/src/industries/oil_well.pnml
+++ b/src/industries/oil_well.pnml
@@ -457,7 +457,7 @@ switch(FEAT_INDUSTRIES, SELF, oil_well_switch_check_availability,
 	current_year) {
 	0..1859: return CB_RESULT_IND_NO_CONSTRUCTION;              // no coal mines before 1860
 	1985..5000000: oil_well_switch_check_availability_map_gen;  // check mode, if the map is generated with that starting year, coal mines should exist
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 item(FEAT_INDUSTRIES, oil_well, INDUSTRY_ID_OIL_WELL) {

--- a/src/industries/ore_smelter.pnml
+++ b/src/industries/ore_smelter.pnml
@@ -1098,7 +1098,7 @@ switch(FEAT_INDUSTRIES, SELF, ore_smelter_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, ore_smelter_switch_check_availability, 
 	current_year) {
 	0..1799: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 if (param_extension_coke_sulphur && !param_extension_painting_industries && !param_extension_ammonia) {

--- a/src/industries/packaging_plant.pnml
+++ b/src/industries/packaging_plant.pnml
@@ -806,7 +806,7 @@ switch(FEAT_INDUSTRIES, SELF, packaging_plant_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, packaging_plant_switch_check_availability, 
 	current_year) {
 	0..1929: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, packaging_plant_switch_extra_text_fund_ext_aluminium, 
@@ -819,7 +819,7 @@ switch(FEAT_INDUSTRIES, SELF, packaging_plant_switch_extra_text_fund_ext_alumini
 switch(FEAT_INDUSTRIES, SELF, packaging_plant_switch_check_availability_ext_aluminium, 
 	current_year) {
 	0..1899: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, packaging_plant_switch_cargo_subtype, getbits(extra_callback_info2, 16, 8)) {
@@ -1004,7 +1004,7 @@ if (param_extension_packaging_industries && !param_extension_aluminium && param_
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        packaging_plant_switch_produce_ext_glass;
 			monthly_prod_change:      packaging_plant_switch_update_last_served_date_ext_glass;
@@ -1039,7 +1039,7 @@ if (param_extension_packaging_industries && param_extension_aluminium && param_e
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        packaging_plant_switch_produce_ext_aluminium_ext_glass;
 			monthly_prod_change:      packaging_plant_switch_update_last_served_date_ext_aluminium_ext_glass;
@@ -1146,7 +1146,7 @@ if (param_extension_packaging_industries && !param_extension_aluminium && param_
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        packaging_plant_switch_produce_ext_glass_ext_paper;
 			monthly_prod_change:      packaging_plant_switch_update_last_served_date_ext_glass_ext_paper;
@@ -1181,7 +1181,7 @@ if (param_extension_packaging_industries && param_extension_aluminium && param_e
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        packaging_plant_switch_produce_ext_aluminium_ext_glass_ext_paper;
 			monthly_prod_change:      packaging_plant_switch_update_last_served_date_ext_aluminium_ext_glass_ext_paper;

--- a/src/industries/paint_factory.pnml
+++ b/src/industries/paint_factory.pnml
@@ -686,7 +686,7 @@ switch(FEAT_INDUSTRIES, SELF, paint_factory_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, paint_factory_switch_check_availability, 
 	current_year) {
 	0..1849: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, paint_factory_switch_update_last_served_date,

--- a/src/industries/paper_mill.pnml
+++ b/src/industries/paper_mill.pnml
@@ -915,7 +915,7 @@ switch(FEAT_INDUSTRIES, SELF, paper_mill_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, paper_mill_switch_check_availability, 
 	current_year) {
 	0..1899: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, paper_mill_switch_update_last_served_date,

--- a/src/industries/petrol_station.pnml
+++ b/src/industries/petrol_station.pnml
@@ -186,7 +186,7 @@ switch(FEAT_INDUSTRIES, SELF, petrol_station_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, petrol_station_switch_check_availability, 
 	current_year) {
 	0..1909: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 item(FEAT_INDUSTRIES, petrol_station, INDUSTRY_ID_PETROL_STATION) {

--- a/src/industries/pharmaceutical_plant.pnml
+++ b/src/industries/pharmaceutical_plant.pnml
@@ -1341,7 +1341,7 @@ switch(FEAT_INDUSTRIES, SELF, pharmaceutical_plant_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, pharmaceutical_plant_switch_check_availability, 
 	current_year) {
 	0..1899: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, pharmaceutical_plant_switch_cargo_subtype, getbits(extra_callback_info2, 16, 8)) {

--- a/src/industries/plastics_plant.pnml
+++ b/src/industries/plastics_plant.pnml
@@ -1207,7 +1207,7 @@ switch(FEAT_INDUSTRIES, SELF, plastics_plant_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, plastics_plant_switch_check_availability, 
 	current_year) {
 	0..1929: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, plastics_plant_switch_cargo_subtype, getbits(extra_callback_info2, 16, 8)) {

--- a/src/industries/port.pnml
+++ b/src/industries/port.pnml
@@ -1662,7 +1662,7 @@ if (!param_extension_aluminium && !param_extension_painting_industries && !param
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    port_produce_cargo_arrival; 
 			produce_256_ticks:        port_switch_produce;
 			monthly_prod_change:      port_switch_prod_change;
@@ -1699,7 +1699,7 @@ if (param_extension_aluminium && !param_extension_painting_industries && !param_
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    port_produce_cargo_arrival; 
 			produce_256_ticks:        port_switch_produce_ext_aluminium;
 			monthly_prod_change:      port_switch_prod_change_ext_aluminium;
@@ -1736,7 +1736,7 @@ if (!param_extension_aluminium && param_extension_painting_industries && !param_
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    port_produce_cargo_arrival; 
 			produce_256_ticks:        port_switch_produce_ext_painting_industries;
 			monthly_prod_change:      port_switch_prod_change_ext_painting_industries;
@@ -1773,7 +1773,7 @@ if (param_extension_aluminium && param_extension_painting_industries && !param_e
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    port_produce_cargo_arrival; 
 			produce_256_ticks:        port_switch_produce_ext_aluminium_ext_painting_industries;
 			monthly_prod_change:      port_switch_prod_change_ext_aluminium_ext_painting_industries;
@@ -1810,7 +1810,7 @@ if (!param_extension_aluminium && !param_extension_painting_industries && param_
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    port_produce_cargo_arrival; 
 			produce_256_ticks:        port_switch_produce_ext_coke_sulphur;
 			monthly_prod_change:      port_switch_prod_change_ext_coke_sulphur;
@@ -1847,7 +1847,7 @@ if (param_extension_aluminium && !param_extension_painting_industries && param_e
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    port_produce_cargo_arrival; 
 			produce_256_ticks:        port_switch_produce_ext_aluminium_ext_coke_sulphur;
 			monthly_prod_change:      port_switch_prod_change_ext_aluminium_ext_coke_sulphur;
@@ -1884,7 +1884,7 @@ if (!param_extension_aluminium && param_extension_painting_industries && param_e
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    port_produce_cargo_arrival; 
 			produce_256_ticks:        port_switch_produce_ext_painting_industries_ext_coke_sulphur;
 			monthly_prod_change:      port_switch_prod_change_ext_painting_industries_ext_coke_sulphur;
@@ -1921,7 +1921,7 @@ if (param_extension_aluminium && param_extension_painting_industries && param_ex
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    port_produce_cargo_arrival; 
 			produce_256_ticks:        port_switch_produce_ext_aluminium_ext_painting_industries_ext_coke_sulphur;
 			monthly_prod_change:      port_switch_prod_change_ext_aluminium_ext_painting_industries_ext_coke_sulphur;

--- a/src/industries/power_plant.pnml
+++ b/src/industries/power_plant.pnml
@@ -619,7 +619,7 @@ switch(FEAT_INDUSTRIES, SELF, power_plant_switch_extra_text_fund,
 
 switch(FEAT_INDUSTRIES, SELF, power_plant_switch_check_availability, current_year) {
 	0..1879: return CB_RESULT_IND_NO_CONSTRUCTION;  
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, power_plant_switch_prod_change_build,

--- a/src/industries/printing_works.pnml
+++ b/src/industries/printing_works.pnml
@@ -208,7 +208,7 @@ switch(FEAT_INDUSTRIES, SELF, printing_works_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, printing_works_switch_check_availability, 
 	current_year) {
 	0..1899: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, printing_works_switch_update_last_served_date,

--- a/src/industries/salt_mine.pnml
+++ b/src/industries/salt_mine.pnml
@@ -606,7 +606,7 @@ switch(FEAT_INDUSTRIES, SELF, salt_mine_switch_extra_text_fund,
 // year < 1800: no creation, 1800 <= year: certain probability
 switch(FEAT_INDUSTRIES, SELF, salt_mine_switch_check_availability, current_year) {
 	0..1799: return CB_RESULT_IND_NO_CONSTRUCTION;               // no salt mines before 1800
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 if (param_extension_basic_inorganic_chemistry) {

--- a/src/industries/sandpit.pnml
+++ b/src/industries/sandpit.pnml
@@ -1222,7 +1222,7 @@ item(FEAT_INDUSTRIES, sandpit, INDUSTRY_ID_SANDPIT) {
 	}
 
 	graphics {
-		//construction_probability: sandpit_switch_check_availability;
+		construction_probability: get_construction_probability;
 		produce_cargo_arrival:    empty_produce; 
 		produce_256_ticks:        sandpit_switch_produce;
 		monthly_prod_change:      sandpit_switch_prod_change;

--- a/src/industries/sawmill.pnml
+++ b/src/industries/sawmill.pnml
@@ -508,6 +508,7 @@ if (!param_extension_fruits) {
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        sawmill_switch_produce;
 			monthly_prod_change:      sawmill_switch_update_last_served_date;
@@ -541,6 +542,7 @@ if (param_extension_fruits) {
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        sawmill_switch_produce_ext_fruits;
 			monthly_prod_change:      sawmill_switch_update_last_served_date_ext_fruits;

--- a/src/industries/soda_plant.pnml
+++ b/src/industries/soda_plant.pnml
@@ -509,7 +509,7 @@ switch(FEAT_INDUSTRIES, SELF, soda_plant_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, soda_plant_switch_check_availability, 
 	current_year) {
 	0..1799: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, soda_plant_switch_update_last_served_date,

--- a/src/industries/steamcracker.pnml
+++ b/src/industries/steamcracker.pnml
@@ -929,7 +929,7 @@ switch(FEAT_INDUSTRIES, SELF, steamcracker_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, steamcracker_switch_check_availability, 
 	current_year) {
 	0..1899: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, steamcracker_switch_update_last_served_date,

--- a/src/industries/steamreformer.pnml
+++ b/src/industries/steamreformer.pnml
@@ -1140,7 +1140,7 @@ switch(FEAT_INDUSTRIES, SELF, steamreformer_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, steamreformer_switch_check_availability, 
 	current_year) {
 	0..1899: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, steamreformer_switch_update_last_served_date,

--- a/src/industries/stockyard.pnml
+++ b/src/industries/stockyard.pnml
@@ -1237,6 +1237,7 @@ if (param_extension_food_industries && !param_extension_packaging_industries) {
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        stockyard_switch_produce;
 			monthly_prod_change:      stockyard_switch_update_last_served_date;
@@ -1270,6 +1271,7 @@ if (param_extension_food_industries && param_extension_packaging_industries) {
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        stockyard_switch_produce_ext_packaging_industries;
 			monthly_prod_change:      stockyard_switch_update_last_served_date_ext_packaging_industries;

--- a/src/industries/textile_mill.pnml
+++ b/src/industries/textile_mill.pnml
@@ -785,7 +785,7 @@ if (param_extension_textile_industries && !param_extension_painting_industries) 
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        textile_mill_switch_produce;
 			monthly_prod_change:      textile_mill_switch_update_last_served_date;
@@ -820,7 +820,7 @@ if (param_extension_textile_industries && param_extension_painting_industries) {
 		}
 			
 		graphics {
-			construction_probability: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+			construction_probability: get_construction_probability;
 			produce_cargo_arrival:    empty_produce; 
 			produce_256_ticks:        textile_mill_switch_produce_ext_painting_industries;
 			monthly_prod_change:      textile_mill_switch_update_last_served_date_ext_painting_industries;

--- a/src/industries/vehicle_distributor.pnml
+++ b/src/industries/vehicle_distributor.pnml
@@ -267,7 +267,7 @@ switch(FEAT_INDUSTRIES, SELF, vehicle_distributor_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, vehicle_distributor_switch_check_availability, 
 	current_year) {
 	0..1909: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, vehicle_distributor_switch_update_last_served_date,

--- a/src/industries/vehicle_factory.pnml
+++ b/src/industries/vehicle_factory.pnml
@@ -1055,7 +1055,7 @@ switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_extra_text_fund,
 switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_check_availability, 
 	current_year) {
 	0..1909: return CB_RESULT_IND_NO_CONSTRUCTION;
-	return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	get_construction_probability;
 }
 
 switch(FEAT_INDUSTRIES, SELF, vehicle_factory_switch_cargo_subtype, getbits(extra_callback_info2, 16, 8)) {

--- a/src/location_checks.pnml
+++ b/src/location_checks.pnml
@@ -36,9 +36,22 @@ switch (FEAT_INDUSTRIES, SELF, is_industry_funded_or_prospected,
 ////////////////////////////////////////////////////////////////////////////////
 switch (FEAT_INDUSTRYTILES, SELF, generation_not_forbidden_by_param, 
 			(getbits(extra_callback_info2, 0, 8) == IND_CREATION_GENERATION) || 
-			(getbits(extra_callback_info2, 0, 8) == IND_CREATION_RANDOM) && !param_forbid_industry_generation)
+			((getbits(extra_callback_info2, 0, 8) == IND_CREATION_RANDOM) && !param_forbid_industry_generation))
 {
 		return;
+}
+
+switch (FEAT_INDUSTRIES, SELF, industry_generation_not_forbidden_by_param,
+	        (getbits(extra_callback_info2, 0, 8) == IND_CREATION_GENERATION) || 
+			((getbits(extra_callback_info2, 0, 8) == IND_CREATION_RANDOM) && !param_forbid_industry_generation))
+{
+	return;
+}
+
+switch (FEAT_INDUSTRIES, SELF, get_construction_probability, [industry_generation_not_forbidden_by_param()])
+{
+	1: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
+	return CB_RESULT_IND_NO_CONSTRUCTION;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The parameter did not have any effect in game. This is now fixed, at least in my test games it worked as expected.
As a side effect it appears that the game generation may now more often run into issues of not being able to place all industries at least once, depending on map size and mountain height.