### PR TITLE
fix: industry funding was broken

### DIFF
--- a/src/location_checks.pnml
+++ b/src/location_checks.pnml
@@ -48,7 +48,7 @@ switch (FEAT_INDUSTRIES, SELF, industry_generation_not_forbidden_by_param,
 	return;
 }
 
-switch (FEAT_INDUSTRIES, SELF, get_construction_probability, [industry_generation_not_forbidden_by_param()])
+switch (FEAT_INDUSTRIES, SELF, get_construction_probability, [is_industry_funded_or_prospected() || industry_generation_not_forbidden_by_param()])
 {
 	1: return CB_RESULT_IND_PROBABILITY_FROM_PROPERTY;
 	return CB_RESULT_IND_NO_CONSTRUCTION;


### PR DESCRIPTION
In the previous version the parameter for not generating industries was repaired, now working too well... you could not fund new industries anymore.