### PR TITLE
fix: make industries fundable also in late game for simple economy model

### DIFF
--- a/src/industries/coal_mine.pnml
+++ b/src/industries/coal_mine.pnml
@@ -591,11 +591,24 @@ switch(FEAT_INDUSTRIES, SELF, coal_mine_switch_extra_text_ext_production_boost,
 	 create_extractive_industry_text_optional_cargo;
 }
 
-switch(FEAT_INDUSTRIES, SELF, coal_mine_switch_extra_text_fund, 
+switch(FEAT_INDUSTRIES, SELF, coal_mine_switch_extra_text_fund_realistic, 
     [STORE_TEMP(string(STR_1800) | string(STR_1950) << 16, TEMP_REGISTER_EXTRA_TEXT_ARG0),
 	current_year]) {
 	1800..1950: return string(STR_EMPTY);
 	return string(STR_INDUSTRY_AVAILABLE_TIMEFRAME);
+}
+
+switch(FEAT_INDUSTRIES, SELF, coal_mine_switch_extra_text_fund_simple, 
+    [STORE_TEMP(string(STR_1800), TEMP_REGISTER_EXTRA_TEXT_ARG0),
+	current_year]) {
+	1800..500000: return string(STR_EMPTY);
+	return string(STR_INDUSTRY_NOT_AVAILABLE_BEFORE);
+}
+
+switch(FEAT_INDUSTRIES, SELF, coal_mine_switch_extra_text_fund, param_economy_model)
+{
+	1: coal_mine_switch_extra_text_fund_realistic;
+	coal_mine_switch_extra_text_fund_simple;
 }
 
 // check creation type (getbits(extra_callback_info2, 0, 8))
@@ -606,10 +619,21 @@ switch(FEAT_INDUSTRIES, SELF, coal_mine_switch_check_availability_map_gen,
 }
 
 // year < 1800: no creation, 1800 <= year < 1950: certain probability, 1950 <= year: no creation (take coal from harbours instead)
-switch(FEAT_INDUSTRIES, SELF, coal_mine_switch_check_availability, current_year) {
+switch(FEAT_INDUSTRIES, SELF, coal_mine_switch_check_availability_realistic, current_year) {
 	0..1799: return CB_RESULT_IND_NO_CONSTRUCTION;               // no coal mines before 1800
 	1950..5000000: coal_mine_switch_check_availability_map_gen;  // check mode, if the map is generated with that starting year, coal mines should exist
 	get_construction_probability;
+}
+
+switch(FEAT_INDUSTRIES, SELF, coal_mine_switch_check_availability_simple, current_year) {
+	0..1799: return CB_RESULT_IND_NO_CONSTRUCTION;               // no coal mines before 1800
+	get_construction_probability;
+}
+
+switch(FEAT_INDUSTRIES, SELF, coal_mine_switch_check_availability, param_economy_model)
+{
+	1: coal_mine_switch_check_availability_realistic;
+	coal_mine_switch_check_availability_simple;
 }
 
 switch(FEAT_INDUSTRIES, SELF, coal_mine_switch_random_prod_change, 

--- a/src/industries/copper_ore_mine.pnml
+++ b/src/industries/copper_ore_mine.pnml
@@ -539,11 +539,24 @@ switch(FEAT_INDUSTRIES, SELF, copper_ore_mine_switch_extra_text_ext_production_b
 	create_extractive_industry_text_optional_cargo;
 }
 
-switch(FEAT_INDUSTRIES, SELF, copper_ore_mine_switch_extra_text_fund, 
+switch(FEAT_INDUSTRIES, SELF, copper_ore_mine_switch_extra_text_fund_realistic, 
     [STORE_TEMP(string(STR_1800) | string(STR_1930) << 16, TEMP_REGISTER_EXTRA_TEXT_ARG0),
 	current_year]) {
 	1800..1930: return string(STR_EMPTY);
 	return string(STR_INDUSTRY_AVAILABLE_TIMEFRAME);
+}
+
+switch(FEAT_INDUSTRIES, SELF, copper_ore_mine_switch_extra_text_fund_simple, 
+    [STORE_TEMP(string(STR_1800), TEMP_REGISTER_EXTRA_TEXT_ARG0),
+	current_year]) {
+	1800..500000: return string(STR_EMPTY);
+	return string(STR_INDUSTRY_NOT_AVAILABLE_BEFORE);
+}
+
+switch(FEAT_INDUSTRIES, SELF, copper_ore_mine_switch_extra_text_fund, param_economy_model)
+{
+	1: copper_ore_mine_switch_extra_text_fund_realistic;
+	copper_ore_mine_switch_extra_text_fund_simple;
 }
 
 // check creation type (getbits(extra_callback_info2, 0, 8))
@@ -554,10 +567,21 @@ switch(FEAT_INDUSTRIES, SELF, copper_ore_mine_switch_check_availability_map_gen,
 }
 
 // year < 1800: no creation, 1800 <= year < 1930: certain probability, 1930 <= year: no creation (take copper ore from harbours instead)
-switch(FEAT_INDUSTRIES, SELF, copper_ore_mine_switch_check_availability, current_year) {
+switch(FEAT_INDUSTRIES, SELF, copper_ore_mine_switch_check_availability_realistic, current_year) {
 	0..1799: return CB_RESULT_IND_NO_CONSTRUCTION;               // no copper ore mines before 1800
 	1930..5000000: copper_ore_mine_switch_check_availability_map_gen;  // check mode, if the map is generated with that starting year, copper ore mines should exist
 	get_construction_probability;
+}
+
+switch(FEAT_INDUSTRIES, SELF, copper_ore_mine_switch_check_availability_simple, current_year) {
+	0..1799: return CB_RESULT_IND_NO_CONSTRUCTION;               // no copper ore mines before 1800
+	get_construction_probability;
+}
+
+switch(FEAT_INDUSTRIES, SELF, copper_ore_mine_switch_check_availability, param_economy_model)
+{
+	1: copper_ore_mine_switch_check_availability_realistic;
+	copper_ore_mine_switch_check_availability_simple;
 }
 
 switch(FEAT_INDUSTRIES, SELF, copper_ore_mine_switch_random_prod_change, 

--- a/src/industries/iron_ore_mine.pnml
+++ b/src/industries/iron_ore_mine.pnml
@@ -556,11 +556,24 @@ switch(FEAT_INDUSTRIES, SELF, iron_ore_mine_switch_extra_text_ext_production_boo
 	 create_extractive_industry_text_optional_cargo;
 }
 
-switch(FEAT_INDUSTRIES, SELF, iron_ore_mine_switch_extra_text_fund, 
+switch(FEAT_INDUSTRIES, SELF, iron_ore_mine_switch_extra_text_fund_realistic, 
     [STORE_TEMP(string(STR_1800) | string(STR_1930) << 16, TEMP_REGISTER_EXTRA_TEXT_ARG0),
 	current_year]) {
 	1800..1930: return string(STR_EMPTY);
 	return string(STR_INDUSTRY_AVAILABLE_TIMEFRAME);
+}
+
+switch(FEAT_INDUSTRIES, SELF, iron_ore_mine_switch_extra_text_fund_simple, 
+    [STORE_TEMP(string(STR_1800), TEMP_REGISTER_EXTRA_TEXT_ARG0),
+	current_year]) {
+	1800..500000: return string(STR_EMPTY);
+	return string(STR_INDUSTRY_NOT_AVAILABLE_BEFORE);
+}
+
+switch(FEAT_INDUSTRIES, SELF, iron_ore_mine_switch_extra_text_fund, param_economy_model)
+{
+	1: iron_ore_mine_switch_extra_text_fund_realistic;
+	iron_ore_mine_switch_extra_text_fund_simple;
 }
 
 // check creation type (getbits(extra_callback_info2, 0, 8))
@@ -571,10 +584,21 @@ switch(FEAT_INDUSTRIES, SELF, iron_ore_mine_switch_check_availability_map_gen,
 }
 
 // year < 1800: no creation, 1800 <= year < 1930: certain probability, 1930 <= year: no creation (take iron ore from harbours instead)
-switch(FEAT_INDUSTRIES, SELF, iron_ore_mine_switch_check_availability, current_year) {
+switch(FEAT_INDUSTRIES, SELF, iron_ore_mine_switch_check_availability_realistic, current_year) {
 	0..1799: return CB_RESULT_IND_NO_CONSTRUCTION;               // no iron ore mines before 1800
 	1930..5000000: iron_ore_mine_switch_check_availability_map_gen;  // check mode, if the map is generated with that starting year, iron ore mines should exist
 	get_construction_probability;
+}
+
+switch(FEAT_INDUSTRIES, SELF, iron_ore_mine_switch_check_availability_simple, current_year) {
+	0..1799: return CB_RESULT_IND_NO_CONSTRUCTION;               // no iron ore mines before 1800
+	get_construction_probability;
+}
+
+switch(FEAT_INDUSTRIES, SELF, iron_ore_mine_switch_check_availability, param_economy_model)
+{
+	1: iron_ore_mine_switch_check_availability_realistic;
+	iron_ore_mine_switch_check_availability_simple;
 }
 
 switch(FEAT_INDUSTRIES, SELF, iron_ore_mine_switch_random_prod_change, 

--- a/src/industries/oil_well.pnml
+++ b/src/industries/oil_well.pnml
@@ -439,11 +439,24 @@ switch(FEAT_INDUSTRIES, SELF, oil_well_switch_extra_text,
 	create_extractive_industry_text;
 }
 
-switch(FEAT_INDUSTRIES, SELF, oil_well_switch_extra_text_fund, 
+switch(FEAT_INDUSTRIES, SELF, oil_well_switch_extra_text_fund_realistic, 
     [STORE_TEMP(string(STR_1860) | string(STR_1985) << 16, TEMP_REGISTER_EXTRA_TEXT_ARG0),
 	current_year]) {
 	1860..1985: return string(STR_EMPTY);
 	return string(STR_INDUSTRY_AVAILABLE_TIMEFRAME);
+}
+
+switch(FEAT_INDUSTRIES, SELF, oil_well_switch_extra_text_fund_simple, 
+    [STORE_TEMP(string(STR_1860), TEMP_REGISTER_EXTRA_TEXT_ARG0),
+	current_year]) {
+	1860..500000: return string(STR_EMPTY);
+	return string(STR_INDUSTRY_NOT_AVAILABLE_BEFORE);
+}
+
+switch(FEAT_INDUSTRIES, SELF, oil_well_switch_extra_text_fund, param_economy_model)
+{
+	1: oil_well_switch_extra_text_fund_realistic;
+	oil_well_switch_extra_text_fund_simple;
 }
 
 // check creation type (getbits(extra_callback_info2, 0, 8))
@@ -454,11 +467,23 @@ switch(FEAT_INDUSTRIES, SELF, oil_well_switch_check_availability_map_gen,
 }
 
 // year < 1860: no creation, 1860 <= year < 1950: certain probability, 1985 <= year: no creation (use oil rigs)
-switch(FEAT_INDUSTRIES, SELF, oil_well_switch_check_availability, 
+switch(FEAT_INDUSTRIES, SELF, oil_well_switch_check_availability_realistic, 
 	current_year) {
 	0..1859: return CB_RESULT_IND_NO_CONSTRUCTION;              // no coal mines before 1860
 	1985..5000000: oil_well_switch_check_availability_map_gen;  // check mode, if the map is generated with that starting year, oil wells should exist
 	get_construction_probability;
+}
+
+switch(FEAT_INDUSTRIES, SELF, oil_well_switch_check_availability_simple, 
+	current_year) {
+	0..1859: return CB_RESULT_IND_NO_CONSTRUCTION;
+	get_construction_probability;
+}
+
+switch(FEAT_INDUSTRIES, SELF, oil_well_switch_check_availability, param_economy_model)
+{
+	1: oil_well_switch_check_availability_realistic;
+	oil_well_switch_check_availability_simple;
 }
 
 switch(FEAT_INDUSTRIES, SELF, oil_well_switch_random_prod_change, 

--- a/src/industries/power_plant.pnml
+++ b/src/industries/power_plant.pnml
@@ -647,8 +647,8 @@ switch(FEAT_INDUSTRIES, SELF, power_plant_switch_produce_ext_coke_sulphur_ext_fr
 switch(FEAT_INDUSTRIES, SELF, power_plant_switch_extra_text_fund, 
 	[STORE_TEMP(string(STR_1880), TEMP_REGISTER_EXTRA_TEXT_ARG0),
 	current_year]) {
-	0..1880: return string(STR_INDUSTRY_NOT_AVAILABLE_BEFORE);
-	return string(STR_EMPTY);
+	1880..500000: return string(STR_EMPTY);
+	return string(STR_INDUSTRY_NOT_AVAILABLE_BEFORE);
 }
 
 switch(FEAT_INDUSTRIES, SELF, power_plant_switch_check_availability, current_year) {


### PR DESCRIPTION
This changeset makes mines and oil wells available to funding/prospecting without end year if the economy model is set to simple economy. When realistic economy is set, the current limitations still apply.

Fixes #54