### PR TITLE
fix: add missing check about construction being allowed

### DIFF
--- a/src/industries/brick_works.pnml
+++ b/src/industries/brick_works.pnml
@@ -708,6 +708,7 @@ if (param_extension_building_materials) {
 		}
 			
 		graphics {
+			construction_probability: get_construction_probability;
 			cargo_input:			  brick_works_switch_input;
 			produce_cargo_arrival:    brick_works_switch_stockpile_check; 
 			produce_256_ticks:        brick_works_switch_produce;


### PR DESCRIPTION
Brickworks was being created even when no industry creation is allowed at all. This was caused by a missing check for the relevant parameter.

Fixes #68 