### PR TITLE
fix: add option to skip checks for incompatible NewGRFs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ In case of a bug report, please provide the exact version of the set that you en
 Without these, and especially without knowing which extensions you turned on or off, it will be impossible to figure out the problem.
 If possible, provide screenshots of any error message.
 
+Important note: If you have disabled the check for incompatible GRFs, I will not look into the issue until you have checked that using an incompatible GRF was not the root cause of the problem.
+
 ## Providing changes
 
 In case you feel like contributing to the set development, feel free to fork the repository and provide your input as a new [pull request](https://github.com/UweDomaratius/GermanIndustries/pulls).

--- a/lang/english.lng
+++ b/lang/english.lng
@@ -73,6 +73,8 @@ STR_PARAM_EXT_VEHICLE :Extension set "Vehicle Industries"
 STR_PARAM_EXT_VEHICLE_DESC :Adds industries and cargos related to the creation of vehicles.{}{}Requires the extensions "Coke and Sulphur", "Basic inorganic chemistry" and "Painting industries" to be activated.
 STR_PARAM_EXT_PRODUCTION_BOOST :Erweiterung "Production boost"
 STR_PARAM_EXT_PRODUCTION_BOOST_DESC :Adds industries to that support the production of fertilizers and explosives, which in turn are used to increase production of primary industries.{}{}Requires the extensions "Ammonia synthesis" or "Coke and Sulphur" to be activated.{}Extension "Ammonia Synthesis" requires the extensions "Basic inorganic chemistry" or "Building Industries" to be activated.{}Extension "Coke and Sulphur" requires the extensions "Basic inorganic chemistry" and "Painting Industries" to be activated.
+STR_PARAM_SKIP_CHECKS :Skip check for incompatible GRFs
+STR_PARAM_SKIP_CHECKS_DESC :If you really insist on using an incompatible NewGRF you can enable this.{}This will void all warranties, corrupt your savegame, may set your PC on fire and God will kill a kitten. You have been warned.
 
 STR_TOWN    :{STRING}
 STR_STATION :{STRING} {STRING}

--- a/lang/german.lng
+++ b/lang/german.lng
@@ -73,6 +73,8 @@ STR_PARAM_EXT_VEHICLE :Erweiterung "Automobilbau"
 STR_PARAM_EXT_VEHICLE_DESC :Fügt Industrien und Frachten hinzu, die mit Automobilbau zusammenhängen.{}{}Erfordert die Erweiterungen "Koks und Schwefel", "Grundlegende anorganische Chemie" und "Farbindustrie".
 STR_PARAM_EXT_PRODUCTION_BOOST :Erweiterung "Produktionsbooster"
 STR_PARAM_EXT_PRODUCTION_BOOST_DESC :Fügt Industrien hinzu, die der Produktion von Dünger und Sprengstoff dienen, mit denen man die Produktion von Primärindustrien erhöhen kann.{}{}Erfordert die Erweiterungen "Ammoniaksynthese" oder "Koks und Schwefel".{}Die Erweiterung "Ammoniaksynthese" benötigt die Erweiterungen "Grundlegende anorganische Chemie" oder "Bauindustrie".{}Die Erweiterung "Koks und Schwefel" benötigt die Erweiterungen "Grundlegende anorganische Chemie" und "Farbindustrie".
+STR_PARAM_SKIP_CHECKS :Überspringe die Prüfung auf inkompatible GRFs
+STR_PARAM_SKIP_CHECKS_DESC :Wer unbedingt inkompatible Sets benutzen will kann das hiermit tun.{}Das wird zu nicht funktionierenden Industrien und kaputten Spielständen führen, kann den PC zerstören und dein Haus in Brand setzen. Beschwer dich also hinterher nicht.
 
 STR_SLOW     :Langsam
 STR_MEDIUM   :Mittel

--- a/src/german_industries.pnml
+++ b/src/german_industries.pnml
@@ -273,6 +273,13 @@ grf {
 			desc: string(STR_PARAM_EXT_PRODUCTION_BOOST_DESC);
 		}
 	}
+	param {
+		param_skip_checks {
+			type: bool;
+			name: string(STR_PARAM_SKIP_CHECKS);
+			desc: string(STR_PARAM_SKIP_CHECKS_DESC);
+		}
+	}
 }
 
 if (ttd_platform != PLATFORM_OPENTTD || openttd_version < version_openttd(14, 0)) {
@@ -325,6 +332,7 @@ if (param_extension_production_boost && (!param_extension_ammonia || !param_exte
 	exit;
 }
 
+if (!param_skip_checks) {
 if (grf_future_status("\F1\25\00\05")) {
 	error(FATAL, string(STR_ERR_INCOMPATIBLE_SET, "FIRS v1"));
 }
@@ -495,6 +503,7 @@ if (grf_future_status("DD\06\01")) {
 }
 if (grf_future_status("\42\58\00\02")) {
 	error(FATAL, string(STR_ERR_INCOMPATIBLE_SET, "Vanilla Industries in Stockpiling mode"));
+}
 }
 
 


### PR DESCRIPTION
For all those who like to live on the edge and enjoy being bombed by errors messages in their game...

Fixes #78