### PR TITLE
fix: issues related to industry closures

### DIFF
--- a/custom_tags.txt
+++ b/custom_tags.txt
@@ -1,0 +1,2 @@
+VERSION:local build 2026-04-21 19:01:38
+TITLE :GIST - German Industries Set

--- a/custom_tags.txt
+++ b/custom_tags.txt
@@ -1,2 +1,0 @@
-VERSION:local build 2026-04-21 19:01:38
-TITLE :GIST - German Industries Set

--- a/lang/english.lng
+++ b/lang/english.lng
@@ -23,6 +23,8 @@ STR_PARAM_FORBID_INDUSTRY_GENERATION :Forbid industry generation
 STR_PARAM_FORBID_INDUSTRY_GENERATION_DESC :When enabled, no industries will spawn during gameplay. Industries will be generated at map generation and can be funded/prospected by the player.
 STR_PARAM_FORBID_INDUSTRY_CLOSURE :Forbid industry closure
 STR_PARAM_FORBID_INDUSTRY_CLOSURE_DESC :When enabled, no industries will close during gameplay. Extractive industries like mines will still close once they run out of materials to produce. Even with closures enabled, industries that are being served will not close.
+STR_PARAM_FORBID_LAST_INDUSTRY_CLOSURE :Forbid industry closure for last industry on map
+STR_PARAM_FORBID_LAST_INDUSTRY_CLOSURE_DESC :When enabled, industries will not be closed if they are the only instance of that industry on the map. Only has an effect if closures of industries are enabled in general.
 STR_PARAM_STOCKPILE_CAP :Behavior when reaching stockpile limit
 STR_PARAM_STOCKPILE_CAP_DESC :Define what to do when the stockpile limit is reached. When set to discard, incoming freight will be discarded. The delivery will be paid, the cargo will simply vanish. When set to stop acceptance, the industry will stop simply not accept the cargo, the vehicle will not be able to unload. See documentation for more details.
 STR_PARAM_STOCKPILE_DISCARD :Discard

--- a/lang/german.lng
+++ b/lang/german.lng
@@ -23,6 +23,8 @@ STR_PARAM_FORBID_INDUSTRY_GENERATION :Verbiete Erzeugung von Industrien
 STR_PARAM_FORBID_INDUSTRY_GENERATION_DESC :Wenn diese Option aktiviert ist, werden Industrien nur noch während des Spielstarts zusammen mit der Karte generiert. Der Spieler kann weiterhin neue Industrien finanzieren.
 STR_PARAM_FORBID_INDUSTRY_CLOSURE :Verbiete das Schließen von Industrien.
 STR_PARAM_FORBID_INDUSTRY_CLOSURE_DESC :Wenn diese Option aktiviert ist, werden Industrien nicht schließen. Minen und ähnliche Industrien werden trotzdem schließen, wenn sie keine Materialien mehr fördern können. Selbst wenn Schließungen erlaubt sind, werden keine Industrien schließen solange sie beliefert werden.
+STR_PARAM_FORBID_LAST_INDUSTRY_CLOSURE :Verbiete das Schließen der einzigen Industrie eines Types.
+STR_PARAM_FORBID_LAST_INDUSTRY_CLOSURE_DESC :Wenn diese Option aktiviert ist, werden Industrien nicht schließen, wenn es nur eine einzige Instanz der Industrie auf der Karte gibt. Hat nur einen Effekt wenn das Schließen von Industrien erlaubt ist.
 STR_PARAM_STOCKPILE_CAP :Verhalten wenn zu viele Rohstoffe in einer Industrie warten
 STR_PARAM_STOCKPILE_CAP_DESC :Bestimmt das Verhalten für den Fall, dass das Lagerlimit für eine Industrie erreicht wird. Wenn man es auf Verwerfen stellt, werden weitere angelieferter Güter verworfen. Die Anlieferung wird aber bezahlt. Wenn man es auf Annahme verweigern stellt, wird die Industrie die Lieferung nicht akzeptieren, das liefernde Fahrzeug kann dann nicht abladen. Die Dokumentation enthält eine genauere Beschreibung.
 STR_PARAM_STOCKPILE_DISCARD :Verwerfen

--- a/src/german_industries.pnml
+++ b/src/german_industries.pnml
@@ -43,6 +43,14 @@ grf {
 		}
 	}
 	param {
+		param_forbid_last_industry_closure {
+			type: bool;
+			name: string(STR_PARAM_FORBID_LAST_INDUSTRY_CLOSURE);
+			desc: string(STR_PARAM_FORBID_LAST_INDUSTRY_CLOSURE_DESC);
+			def_value: 1;
+		}
+	}
+	param {
 		param_max_industries_on_map {
 			type: int;
 			name: string(STR_PARAM_MAX_INDUSTRIES_ON_MAP);

--- a/src/industries/acid_plant.pnml
+++ b/src/industries/acid_plant.pnml
@@ -1265,7 +1265,6 @@ if (param_extension_coke_sulphur && !param_extension_basic_inorganic_chemistry &
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [acid_plant_tilelayout_1, acid_plant_tilelayout_2, acid_plant_tilelayout_3, acid_plant_tilelayout_4, acid_plant_tilelayout_5, acid_plant_tilelayout_6];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ACID_PLANT);
@@ -1275,6 +1274,14 @@ if (param_extension_coke_sulphur && !param_extension_basic_inorganic_chemistry &
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SULP"),produce_cargo("ACID",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ORE_SMELTER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1301,7 +1308,6 @@ if (param_extension_coke_sulphur && param_extension_basic_inorganic_chemistry &&
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [acid_plant_tilelayout_1, acid_plant_tilelayout_2, acid_plant_tilelayout_3, acid_plant_tilelayout_4, acid_plant_tilelayout_5, acid_plant_tilelayout_6];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ACID_PLANT);
@@ -1311,6 +1317,14 @@ if (param_extension_coke_sulphur && param_extension_basic_inorganic_chemistry &&
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SULP"),accept_cargo("H2__"),accept_cargo("CHLO"),produce_cargo("ACID",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ORE_SMELTER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1337,7 +1351,6 @@ if (param_extension_coke_sulphur && !param_extension_basic_inorganic_chemistry &
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [acid_plant_tilelayout_1, acid_plant_tilelayout_2, acid_plant_tilelayout_3, acid_plant_tilelayout_4, acid_plant_tilelayout_5, acid_plant_tilelayout_6];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ACID_PLANT);
@@ -1347,6 +1360,14 @@ if (param_extension_coke_sulphur && !param_extension_basic_inorganic_chemistry &
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SULP"),accept_cargo("O2__"),accept_cargo("NH3_"),produce_cargo("ACID",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ORE_SMELTER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1373,7 +1394,6 @@ if (param_extension_coke_sulphur && param_extension_basic_inorganic_chemistry &&
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [acid_plant_tilelayout_1, acid_plant_tilelayout_2, acid_plant_tilelayout_3, acid_plant_tilelayout_4, acid_plant_tilelayout_5, acid_plant_tilelayout_6];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ACID_PLANT);
@@ -1383,6 +1403,14 @@ if (param_extension_coke_sulphur && param_extension_basic_inorganic_chemistry &&
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SULP"),accept_cargo("H2__"),accept_cargo("CHLO"),accept_cargo("O2__"),accept_cargo("NH3_"),produce_cargo("ACID",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ORE_SMELTER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/aluminium_plant.pnml
+++ b/src/industries/aluminium_plant.pnml
@@ -1674,7 +1674,6 @@ if (param_extension_aluminium && !param_extension_basic_inorganic_chemistry && !
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [aluminium_plant_tilelayout_1, aluminium_plant_tilelayout_2, aluminium_plant_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ALUMINIUM_PLANT);
@@ -1684,6 +1683,14 @@ if (param_extension_aluminium && !param_extension_basic_inorganic_chemistry && !
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("AORE"),produce_cargo("ALUM",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ALUMINIUM_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1709,7 +1716,6 @@ if (param_extension_aluminium && param_extension_basic_inorganic_chemistry && !p
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [aluminium_plant_tilelayout_1, aluminium_plant_tilelayout_2, aluminium_plant_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ALUMINIUM_PLANT);
@@ -1719,6 +1725,14 @@ if (param_extension_aluminium && param_extension_basic_inorganic_chemistry && !p
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("AORE"),accept_cargo("LYE_"),produce_cargo("ALUM",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ALUMINIUM_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1745,7 +1759,7 @@ if (param_extension_aluminium && !param_extension_basic_inorganic_chemistry && p
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [aluminium_plant_tilelayout_1, aluminium_plant_tilelayout_2, aluminium_plant_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
+			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ALUMINIUM_PLANT);
@@ -1780,7 +1794,7 @@ if (param_extension_aluminium && param_extension_basic_inorganic_chemistry && pa
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [aluminium_plant_tilelayout_1, aluminium_plant_tilelayout_2, aluminium_plant_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
+			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ALUMINIUM_PLANT);

--- a/src/industries/aluminium_plant.pnml
+++ b/src/industries/aluminium_plant.pnml
@@ -1759,7 +1759,6 @@ if (param_extension_aluminium && !param_extension_basic_inorganic_chemistry && p
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [aluminium_plant_tilelayout_1, aluminium_plant_tilelayout_2, aluminium_plant_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ALUMINIUM_PLANT);
@@ -1769,6 +1768,14 @@ if (param_extension_aluminium && !param_extension_basic_inorganic_chemistry && p
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("AORE"),accept_cargo("SCMT"),produce_cargo("ALUM",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ALUMINIUM_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1794,7 +1801,6 @@ if (param_extension_aluminium && param_extension_basic_inorganic_chemistry && pa
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [aluminium_plant_tilelayout_1, aluminium_plant_tilelayout_2, aluminium_plant_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ALUMINIUM_PLANT);
@@ -1804,6 +1810,14 @@ if (param_extension_aluminium && param_extension_basic_inorganic_chemistry && pa
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("AORE"),accept_cargo("LYE_"),accept_cargo("SCMT"),produce_cargo("ALUM",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ALUMINIUM_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/ammonia_plant.pnml
+++ b/src/industries/ammonia_plant.pnml
@@ -1164,7 +1164,6 @@ if (param_extension_ammonia) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [ammonia_plant_tilelayout_1,ammonia_plant_tilelayout_2,ammonia_plant_tilelayout_3,ammonia_plant_tilelayout_4,ammonia_plant_tilelayout_5,ammonia_plant_tilelayout_6,ammonia_plant_tilelayout_7];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_AMMONIA_PLANT);
@@ -1174,6 +1173,14 @@ if (param_extension_ammonia) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("H2__"),accept_cargo("N2__"),produce_cargo("NH3_",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_AMMONIA_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/ammonium_nitrate_plant.pnml
+++ b/src/industries/ammonium_nitrate_plant.pnml
@@ -873,7 +873,6 @@ if (param_extension_production_boost) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [ammonium_nitrate_plant_tilelayout_1,ammonium_nitrate_plant_tilelayout_2,ammonium_nitrate_plant_tilelayout_3,ammonium_nitrate_plant_tilelayout_4,ammonium_nitrate_plant_tilelayout_5,ammonium_nitrate_plant_tilelayout_6];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_AMMONIUM_NITRATE_PLANT);
@@ -883,6 +882,14 @@ if (param_extension_production_boost) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("ACID"),accept_cargo("NH3_"),produce_cargo("NHNO",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_AMMONIUM_NITRATE_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/animal_farm.pnml
+++ b/src/industries/animal_farm.pnml
@@ -492,7 +492,6 @@ if (param_extension_food_industries && !param_extension_textile_industries && !p
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [animal_farm_industry_layout_1_tilelayout,animal_farm_industry_layout_2_tilelayout,animal_farm_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ANIMAL_FARM);
@@ -503,6 +502,14 @@ if (param_extension_food_industries && !param_extension_textile_industries && !p
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GRAI"),produce_cargo("LVST",0),produce_cargo("MILK",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ANIMAL_FARM));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {
@@ -528,7 +535,6 @@ if (param_extension_food_industries && param_extension_textile_industries && !pa
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [animal_farm_industry_layout_1_tilelayout,animal_farm_industry_layout_2_tilelayout,animal_farm_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ANIMAL_FARM);
@@ -540,6 +546,14 @@ if (param_extension_food_industries && param_extension_textile_industries && !pa
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GRAI"),produce_cargo("LVST",0),produce_cargo("MILK",0),produce_cargo("WOOL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ANIMAL_FARM));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {
@@ -565,7 +579,6 @@ if (param_extension_food_industries && !param_extension_textile_industries && pa
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [animal_farm_industry_layout_1_tilelayout,animal_farm_industry_layout_2_tilelayout,animal_farm_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ANIMAL_FARM);
@@ -577,6 +590,14 @@ if (param_extension_food_industries && !param_extension_textile_industries && pa
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GRAI"),produce_cargo("LVST",0),produce_cargo("MILK",0),produce_cargo("BIOM",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ANIMAL_FARM));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {
@@ -602,7 +623,6 @@ if (param_extension_food_industries && param_extension_textile_industries && par
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [animal_farm_industry_layout_1_tilelayout,animal_farm_industry_layout_2_tilelayout,animal_farm_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ANIMAL_FARM);
@@ -614,6 +634,14 @@ if (param_extension_food_industries && param_extension_textile_industries && par
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GRAI"),produce_cargo("LVST",0),produce_cargo("MILK",0),produce_cargo("WOOL",0),produce_cargo("BIOM",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ANIMAL_FARM));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {

--- a/src/industries/appliance_factory.pnml
+++ b/src/industries/appliance_factory.pnml
@@ -995,7 +995,6 @@ if (param_extension_metallurgy && !param_extension_packaging_industries) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [appliance_factory_tilelayout_1,appliance_factory_tilelayout_2,appliance_factory_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_APPLIANCE_FACTORY);
@@ -1005,6 +1004,14 @@ if (param_extension_metallurgy && !param_extension_packaging_industries) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("ENSP"),accept_cargo("STWR"),accept_cargo("PLAS"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_APPLIANCE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1031,7 +1038,6 @@ if (param_extension_metallurgy && param_extension_packaging_industries) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [appliance_factory_tilelayout_1,appliance_factory_tilelayout_2,appliance_factory_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_APPLIANCE_FACTORY);
@@ -1041,6 +1047,14 @@ if (param_extension_metallurgy && param_extension_packaging_industries) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("ENSP"),accept_cargo("STWR"),accept_cargo("MNSP"),accept_cargo("PLAS"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_APPLIANCE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/biorefinery.pnml
+++ b/src/industries/biorefinery.pnml
@@ -1081,7 +1081,6 @@ if (param_extension_fruits) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [biorefinery_tilelayout_1, biorefinery_tilelayout_2, biorefinery_tilelayout_3, biorefinery_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_BIOREFINERY);
@@ -1091,6 +1090,14 @@ if (param_extension_fruits) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("BIOM"),accept_cargo("FRUT"),produce_cargo("PETR",0),produce_cargo("C2H4",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_BIOREFINERY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/brewery.pnml
+++ b/src/industries/brewery.pnml
@@ -589,7 +589,6 @@ if (param_extension_food_industries && !param_extension_glass) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [brewery_tilelayout_1,brewery_tilelayout_2,brewery_tilelayout_3,brewery_tilelayout_4,brewery_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_BREWERY);
@@ -599,6 +598,14 @@ if (param_extension_food_industries && !param_extension_glass) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GRAI"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_BREWERY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -624,7 +631,6 @@ if (param_extension_food_industries && param_extension_glass) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [brewery_tilelayout_1,brewery_tilelayout_2,brewery_tilelayout_3,brewery_tilelayout_4,brewery_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_BREWERY);
@@ -634,6 +640,14 @@ if (param_extension_food_industries && param_extension_glass) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GRAI"),accept_cargo("GLAS"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_BREWERY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/brick_works.pnml
+++ b/src/industries/brick_works.pnml
@@ -695,7 +695,6 @@ if (param_extension_building_materials) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [brick_works_tilelayout_1,brick_works_tilelayout_2,brick_works_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_BRICK_WORKS);
@@ -705,6 +704,14 @@ if (param_extension_building_materials) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COAL"),accept_cargo("WOOD"),produce_cargo("BDMT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_BRICK_WORKS));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/builders_yard.pnml
+++ b/src/industries/builders_yard.pnml
@@ -369,7 +369,6 @@ if (param_extension_building_materials) {
 			life_type: IND_LIFE_TYPE_BLACK_HOLE;
 			min_cargo_distr: 1;
 			layouts: [builders_yard_tilelayout_1, builders_yard_tilelayout_2, builders_yard_tilelayout_3, builders_yard_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_BUILDERS_YARD);
@@ -380,6 +379,14 @@ if (param_extension_building_materials) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("WDPR"),accept_cargo("SAND"),accept_cargo("CMNT"),accept_cargo("BDMT")];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_BUILDERS_YARD));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 		graphics {
 			construction_probability: get_construction_probability;
@@ -402,7 +409,6 @@ if (!param_extension_building_materials) {
 			life_type: IND_LIFE_TYPE_BLACK_HOLE;
 			min_cargo_distr: 1;
 			layouts: [builders_yard_tilelayout_1, builders_yard_tilelayout_2, builders_yard_tilelayout_3, builders_yard_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_BUILDERS_YARD);
@@ -413,6 +419,14 @@ if (!param_extension_building_materials) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("WDPR")];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_BUILDERS_YARD));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 		graphics {
 			construction_probability: get_construction_probability;

--- a/src/industries/carbon_black_plant.pnml
+++ b/src/industries/carbon_black_plant.pnml
@@ -791,7 +791,6 @@ if (param_extension_painting_industries && !param_extension_organic_chemistry &&
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [carbon_black_plant_tilelayout_1,carbon_black_plant_tilelayout_2,carbon_black_plant_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_CARBON_BLACK_PLANT);
@@ -801,6 +800,14 @@ if (param_extension_painting_industries && !param_extension_organic_chemistry &&
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("OIL_"),accept_cargo("COAL"),produce_cargo("CBLK",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_CARBON_BLACK_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -827,7 +834,6 @@ if (param_extension_painting_industries && param_extension_organic_chemistry && 
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [carbon_black_plant_tilelayout_1,carbon_black_plant_tilelayout_2,carbon_black_plant_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_CARBON_BLACK_PLANT);
@@ -837,6 +843,14 @@ if (param_extension_painting_industries && param_extension_organic_chemistry && 
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("RFPR"),accept_cargo("COAL"),produce_cargo("CBLK",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_CARBON_BLACK_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -863,7 +877,6 @@ if (param_extension_painting_industries && !param_extension_organic_chemistry &&
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [carbon_black_plant_tilelayout_1,carbon_black_plant_tilelayout_2,carbon_black_plant_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_CARBON_BLACK_PLANT);
@@ -873,6 +886,14 @@ if (param_extension_painting_industries && !param_extension_organic_chemistry &&
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("OIL_"),accept_cargo("COAL"),accept_cargo("O2__"),produce_cargo("CBLK",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_CARBON_BLACK_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -899,7 +920,6 @@ if (param_extension_painting_industries && param_extension_organic_chemistry && 
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [carbon_black_plant_tilelayout_1,carbon_black_plant_tilelayout_2,carbon_black_plant_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_CARBON_BLACK_PLANT);
@@ -909,6 +929,14 @@ if (param_extension_painting_industries && param_extension_organic_chemistry && 
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("RFPR"),accept_cargo("COAL"),accept_cargo("O2__"),produce_cargo("CBLK",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_CARBON_BLACK_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/cement_plant.pnml
+++ b/src/industries/cement_plant.pnml
@@ -1058,7 +1058,6 @@ if (param_extension_building_materials) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [cement_plant_tilelayout_1,cement_plant_tilelayout_2,cement_plant_tilelayout_3,cement_plant_tilelayout_4,cement_plant_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_CEMENT_PLANT);
@@ -1068,6 +1067,14 @@ if (param_extension_building_materials) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SAND"),accept_cargo("LIME"),produce_cargo("CMNT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_CEMENT_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/chlor_alkali_plant.pnml
+++ b/src/industries/chlor_alkali_plant.pnml
@@ -935,7 +935,6 @@ if (param_extension_basic_inorganic_chemistry) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [chlor_alkali_plant_tilelayout_1,chlor_alkali_plant_tilelayout_2,chlor_alkali_plant_tilelayout_3,chlor_alkali_plant_tilelayout_4,chlor_alkali_plant_tilelayout_5,chlor_alkali_plant_tilelayout_6];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_CHLOR_ALKALI_PLANT);
@@ -945,6 +944,14 @@ if (param_extension_basic_inorganic_chemistry) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SALT"),produce_cargo("CHLO",0),produce_cargo("LYE_",0),produce_cargo("H2__",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_CHLOR_ALKALI_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/cleaning_products_factory.pnml
+++ b/src/industries/cleaning_products_factory.pnml
@@ -1267,7 +1267,6 @@ if (param_extension_ammonia && !param_extension_coke_sulphur && !param_extension
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [cleaning_products_factory_tilelayout_1,cleaning_products_factory_tilelayout_2,cleaning_products_factory_tilelayout_3,cleaning_products_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_CLEANING_PRODUCTS_FACTORY);
@@ -1277,6 +1276,14 @@ if (param_extension_ammonia && !param_extension_coke_sulphur && !param_extension
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SASH"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_CLEANING_PRODUCTS_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1303,7 +1310,6 @@ if (param_extension_ammonia && param_extension_coke_sulphur && !param_extension_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [cleaning_products_factory_tilelayout_1,cleaning_products_factory_tilelayout_2,cleaning_products_factory_tilelayout_3,cleaning_products_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_CLEANING_PRODUCTS_FACTORY);
@@ -1313,6 +1319,14 @@ if (param_extension_ammonia && param_extension_coke_sulphur && !param_extension_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SASH"),accept_cargo("ACID"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_CLEANING_PRODUCTS_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1339,7 +1353,6 @@ if (param_extension_ammonia && !param_extension_coke_sulphur && param_extension_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [cleaning_products_factory_tilelayout_1,cleaning_products_factory_tilelayout_2,cleaning_products_factory_tilelayout_3,cleaning_products_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_CLEANING_PRODUCTS_FACTORY);
@@ -1350,6 +1363,14 @@ if (param_extension_ammonia && !param_extension_coke_sulphur && param_extension_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SASH"),accept_cargo("MNSP"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_CLEANING_PRODUCTS_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1376,7 +1397,6 @@ if (param_extension_ammonia && param_extension_coke_sulphur && param_extension_p
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [cleaning_products_factory_tilelayout_1,cleaning_products_factory_tilelayout_2,cleaning_products_factory_tilelayout_3,cleaning_products_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_CLEANING_PRODUCTS_FACTORY);
@@ -1386,6 +1406,14 @@ if (param_extension_ammonia && param_extension_coke_sulphur && param_extension_p
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SASH"),accept_cargo("ACID"),accept_cargo("MNSP"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_CLEANING_PRODUCTS_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1412,7 +1440,6 @@ if (param_extension_ammonia && !param_extension_coke_sulphur && !param_extension
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [cleaning_products_factory_tilelayout_1,cleaning_products_factory_tilelayout_2,cleaning_products_factory_tilelayout_3,cleaning_products_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_CLEANING_PRODUCTS_FACTORY);
@@ -1422,6 +1449,14 @@ if (param_extension_ammonia && !param_extension_coke_sulphur && !param_extension
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SASH"),accept_cargo("POTA"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_CLEANING_PRODUCTS_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1448,7 +1483,6 @@ if (param_extension_ammonia && param_extension_coke_sulphur && !param_extension_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [cleaning_products_factory_tilelayout_1,cleaning_products_factory_tilelayout_2,cleaning_products_factory_tilelayout_3,cleaning_products_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_CLEANING_PRODUCTS_FACTORY);
@@ -1458,6 +1492,14 @@ if (param_extension_ammonia && param_extension_coke_sulphur && !param_extension_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SASH"),accept_cargo("ACID"),accept_cargo("POTA"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_CLEANING_PRODUCTS_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1484,7 +1526,6 @@ if (param_extension_ammonia && !param_extension_coke_sulphur && param_extension_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [cleaning_products_factory_tilelayout_1,cleaning_products_factory_tilelayout_2,cleaning_products_factory_tilelayout_3,cleaning_products_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_CLEANING_PRODUCTS_FACTORY);
@@ -1494,6 +1535,14 @@ if (param_extension_ammonia && !param_extension_coke_sulphur && param_extension_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SASH"),accept_cargo("MNSP"),accept_cargo("POTA"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_CLEANING_PRODUCTS_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1520,7 +1569,6 @@ if (param_extension_ammonia && param_extension_coke_sulphur && param_extension_p
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [cleaning_products_factory_tilelayout_1,cleaning_products_factory_tilelayout_2,cleaning_products_factory_tilelayout_3,cleaning_products_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_CLEANING_PRODUCTS_FACTORY);
@@ -1530,6 +1578,14 @@ if (param_extension_ammonia && param_extension_coke_sulphur && param_extension_p
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SASH"),accept_cargo("ACID"),accept_cargo("MNSP"),accept_cargo("POTA"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_CLEANING_PRODUCTS_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/clothing_plant.pnml
+++ b/src/industries/clothing_plant.pnml
@@ -464,7 +464,6 @@ if (param_extension_textile_industries && !param_extension_packaging_industries)
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [clothing_plant_tilelayout_1, clothing_plant_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_CLOTHING_PLANT);
@@ -474,6 +473,14 @@ if (param_extension_textile_industries && !param_extension_packaging_industries)
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("TEXT"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_CLOTHING_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -499,7 +506,6 @@ if (param_extension_textile_industries && param_extension_packaging_industries) 
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [clothing_plant_tilelayout_1, clothing_plant_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_CLOTHING_PLANT);
@@ -509,6 +515,14 @@ if (param_extension_textile_industries && param_extension_packaging_industries) 
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("TEXT"),accept_cargo("MNSP"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_CLOTHING_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/coal_liquefaction_plant.pnml
+++ b/src/industries/coal_liquefaction_plant.pnml
@@ -1220,7 +1220,6 @@ if (param_extension_organic_chemistry) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [coal_liquefaction_plant_tilelayout_1, coal_liquefaction_plant_tilelayout_2, coal_liquefaction_plant_tilelayout_3, coal_liquefaction_plant_tilelayout_4, coal_liquefaction_plant_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_COAL_LIQUEFACTION_PLANT);
@@ -1230,6 +1229,14 @@ if (param_extension_organic_chemistry) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COAL"),accept_cargo("H2__"),produce_cargo("PETR",0),produce_cargo("C2H4",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_COAL_LIQUEFACTION_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/coal_mine.pnml
+++ b/src/industries/coal_mine.pnml
@@ -670,7 +670,7 @@ if (!param_extension_production_boost) {
 			life_type: IND_LIFE_TYPE_EXTRACTIVE;
 			min_cargo_distr: 1;
 			layouts: [coal_mine_industry_layout_1_tilelayout,coal_mine_industry_layout_2_tilelayout,coal_mine_industry_layout_3_tilelayout,coal_mine_industry_layout_4_tilelayout,coal_mine_industry_layout_5_tilelayout,coal_mine_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
+			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_COAL_MINE;
@@ -705,7 +705,7 @@ if (param_extension_production_boost) {
 			life_type: IND_LIFE_TYPE_EXTRACTIVE;
 			min_cargo_distr: 1;
 			layouts: [coal_mine_industry_layout_1_tilelayout,coal_mine_industry_layout_2_tilelayout,coal_mine_industry_layout_3_tilelayout,coal_mine_industry_layout_4_tilelayout,coal_mine_industry_layout_5_tilelayout,coal_mine_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
+			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_COAL_MINE;

--- a/src/industries/coke_oven.pnml
+++ b/src/industries/coke_oven.pnml
@@ -2995,7 +2995,6 @@ if (param_extension_coke_sulphur) {
 					  coke_oven_tilelayout_21, coke_oven_tilelayout_22, coke_oven_tilelayout_23, coke_oven_tilelayout_24, coke_oven_tilelayout_25, coke_oven_tilelayout_26, coke_oven_tilelayout_27, coke_oven_tilelayout_28, coke_oven_tilelayout_29, coke_oven_tilelayout_30,
 					  coke_oven_tilelayout_31, coke_oven_tilelayout_32, coke_oven_tilelayout_33, coke_oven_tilelayout_34, coke_oven_tilelayout_35, coke_oven_tilelayout_36, coke_oven_tilelayout_37, coke_oven_tilelayout_38, coke_oven_tilelayout_39, coke_oven_tilelayout_40
 			];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_COKE_OVEN);
@@ -3005,6 +3004,14 @@ if (param_extension_coke_sulphur) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COAL"),produce_cargo("COKE",0),produce_cargo("SULP",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_COKE_OVEN));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/copper_ore_mine.pnml
+++ b/src/industries/copper_ore_mine.pnml
@@ -622,7 +622,7 @@ if (param_extension_painting_industries && !param_extension_coke_sulphur && !par
 			life_type: IND_LIFE_TYPE_EXTRACTIVE;
 			min_cargo_distr: 1;
 			layouts: [copper_ore_mine_industry_layout_1_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
+			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_COPPER_ORE_MINE;
@@ -657,7 +657,7 @@ if (param_extension_painting_industries && param_extension_coke_sulphur && !para
 			life_type: IND_LIFE_TYPE_EXTRACTIVE;
 			min_cargo_distr: 1;
 			layouts: [copper_ore_mine_industry_layout_1_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
+			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_COPPER_ORE_MINE;
@@ -692,7 +692,7 @@ if (param_extension_painting_industries && !param_extension_coke_sulphur && para
 			life_type: IND_LIFE_TYPE_EXTRACTIVE;
 			min_cargo_distr: 1;
 			layouts: [copper_ore_mine_industry_layout_1_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
+			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_COPPER_ORE_MINE;
@@ -728,7 +728,7 @@ if (param_extension_painting_industries && param_extension_coke_sulphur && param
 			life_type: IND_LIFE_TYPE_EXTRACTIVE;
 			min_cargo_distr: 1;
 			layouts: [copper_ore_mine_industry_layout_1_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
+			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_COPPER_ORE_MINE;

--- a/src/industries/copper_smelter.pnml
+++ b/src/industries/copper_smelter.pnml
@@ -1459,7 +1459,6 @@ if (param_extension_painting_industries && !param_extension_coke_sulphur && !par
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [copper_smelter_tilelayout_1, copper_smelter_tilelayout_2, copper_smelter_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_COPPER_SMELTER);
@@ -1469,6 +1468,14 @@ if (param_extension_painting_industries && !param_extension_coke_sulphur && !par
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CORE"),produce_cargo("COPR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_COPPER_SMELTER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1495,7 +1502,6 @@ if (param_extension_painting_industries && param_extension_coke_sulphur && !para
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [copper_smelter_tilelayout_1, copper_smelter_tilelayout_2, copper_smelter_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_COPPER_SMELTER);
@@ -1505,6 +1511,14 @@ if (param_extension_painting_industries && param_extension_coke_sulphur && !para
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CORE"),accept_cargo("ACID"),produce_cargo("COPR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_COPPER_SMELTER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1531,7 +1545,6 @@ if (param_extension_painting_industries && !param_extension_coke_sulphur && para
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [copper_smelter_tilelayout_1, copper_smelter_tilelayout_2, copper_smelter_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_COPPER_SMELTER);
@@ -1541,6 +1554,14 @@ if (param_extension_painting_industries && !param_extension_coke_sulphur && para
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CORE"),accept_cargo("SCMT"),produce_cargo("COPR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_COPPER_SMELTER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1567,7 +1588,6 @@ if (param_extension_painting_industries && param_extension_coke_sulphur && param
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [copper_smelter_tilelayout_1, copper_smelter_tilelayout_2, copper_smelter_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_COPPER_SMELTER);
@@ -1577,6 +1597,14 @@ if (param_extension_painting_industries && param_extension_coke_sulphur && param
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CORE"),accept_cargo("ACID"),accept_cargo("SCMT"),produce_cargo("COPR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_COPPER_SMELTER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/cryo_plant.pnml
+++ b/src/industries/cryo_plant.pnml
@@ -817,7 +817,6 @@ if (param_extension_ammonia) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [cryo_plant_industry_layout_1_tilelayout,cryo_plant_industry_layout_2_tilelayout,cryo_plant_industry_layout_3_tilelayout,cryo_plant_industry_layout_4_tilelayout,cryo_plant_industry_layout_5_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_CRYO_PLANT);
@@ -828,6 +827,14 @@ if (param_extension_ammonia) {
 			remove_cost_multiplier: 0;
 			cargo_types: [produce_cargo("O2__",0), produce_cargo("N2__",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_CRYO_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {

--- a/src/industries/dairy.pnml
+++ b/src/industries/dairy.pnml
@@ -1256,7 +1256,6 @@ if (param_extension_food_industries && !param_extension_basic_inorganic_chemistr
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [dairy_tilelayout_1,dairy_tilelayout_2,dairy_tilelayout_3,dairy_tilelayout_4,dairy_tilelayout_5,dairy_tilelayout_6];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_DAIRY);
@@ -1266,6 +1265,14 @@ if (param_extension_food_industries && !param_extension_basic_inorganic_chemistr
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("MILK"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_DAIRY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1291,7 +1298,6 @@ if (param_extension_food_industries && param_extension_basic_inorganic_chemistry
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [dairy_tilelayout_1,dairy_tilelayout_2,dairy_tilelayout_3,dairy_tilelayout_4,dairy_tilelayout_5,dairy_tilelayout_6];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_DAIRY);
@@ -1301,6 +1307,14 @@ if (param_extension_food_industries && param_extension_basic_inorganic_chemistry
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("MILK"),accept_cargo("LYE_"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_DAIRY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1326,7 +1340,6 @@ if (param_extension_food_industries && !param_extension_basic_inorganic_chemistr
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [dairy_tilelayout_1,dairy_tilelayout_2,dairy_tilelayout_3,dairy_tilelayout_4,dairy_tilelayout_5,dairy_tilelayout_6];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_DAIRY);
@@ -1336,6 +1349,14 @@ if (param_extension_food_industries && !param_extension_basic_inorganic_chemistr
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("MILK"),accept_cargo("MNSP"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_DAIRY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1361,7 +1382,6 @@ if (param_extension_food_industries && param_extension_basic_inorganic_chemistry
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [dairy_tilelayout_1,dairy_tilelayout_2,dairy_tilelayout_3,dairy_tilelayout_4,dairy_tilelayout_5,dairy_tilelayout_6];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_DAIRY);
@@ -1371,6 +1391,14 @@ if (param_extension_food_industries && param_extension_basic_inorganic_chemistry
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("MILK"),accept_cargo("LYE_"),accept_cargo("MNSP"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_DAIRY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/department_store.pnml
+++ b/src/industries/department_store.pnml
@@ -128,7 +128,6 @@ item(FEAT_INDUSTRIES, department_store, INDUSTRY_ID_DEPARTMENT_STORE) {
 		life_type: IND_LIFE_TYPE_BLACK_HOLE;
 		min_cargo_distr: 1;
 		layouts: [department_store_tilelayout];
-		spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_ONLY_IN_TOWNS);
 		conflicting_ind_types: [];
 		random_sound_effects: [];
 		name: string(STR_IND_DEPARTMENT_STORE);
@@ -139,6 +138,14 @@ item(FEAT_INDUSTRIES, department_store, INDUSTRY_ID_DEPARTMENT_STORE) {
 		remove_cost_multiplier: 0;
 		cargo_types: [accept_cargo("GOOD")];
 		nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_DEPARTMENT_STORE));
+	}
+	if (param_forbid_last_industry_closure)
+	{
+		property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ONLY_IN_TOWNS); }
+	}
+	else
+	{
+		property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ONLY_IN_TOWNS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 	}
         
 	graphics {

--- a/src/industries/explosives_factory.pnml
+++ b/src/industries/explosives_factory.pnml
@@ -1067,7 +1067,6 @@ if (param_extension_production_boost && !param_extension_organic_chemistry && !p
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [explosives_factory_tilelayout_1,explosives_factory_tilelayout_2,explosives_factory_tilelayout_3,explosives_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_EXPLOSIVES_FACTORY);
@@ -1077,6 +1076,14 @@ if (param_extension_production_boost && !param_extension_organic_chemistry && !p
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("ACID"),accept_cargo("NHNO"),produce_cargo("BOOM",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_EXPLOSIVES_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1103,7 +1110,6 @@ if (param_extension_production_boost && !param_extension_organic_chemistry && pa
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [explosives_factory_tilelayout_1,explosives_factory_tilelayout_2,explosives_factory_tilelayout_3,explosives_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_EXPLOSIVES_FACTORY);
@@ -1113,6 +1119,14 @@ if (param_extension_production_boost && !param_extension_organic_chemistry && pa
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("ACID"),accept_cargo("NHNO"),accept_cargo("ALUM"),produce_cargo("BOOM",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_EXPLOSIVES_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1139,7 +1153,6 @@ if (param_extension_production_boost && param_extension_organic_chemistry && !pa
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [explosives_factory_tilelayout_1,explosives_factory_tilelayout_2,explosives_factory_tilelayout_3,explosives_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_EXPLOSIVES_FACTORY);
@@ -1149,6 +1162,14 @@ if (param_extension_production_boost && param_extension_organic_chemistry && !pa
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("ACID"),accept_cargo("NHNO"),accept_cargo("PETR"),produce_cargo("BOOM",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_EXPLOSIVES_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1175,7 +1196,6 @@ if (param_extension_production_boost && param_extension_organic_chemistry && par
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [explosives_factory_tilelayout_1,explosives_factory_tilelayout_2,explosives_factory_tilelayout_3,explosives_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_EXPLOSIVES_FACTORY);
@@ -1185,6 +1205,14 @@ if (param_extension_production_boost && param_extension_organic_chemistry && par
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("ACID"),accept_cargo("NHNO"),accept_cargo("ALUM"),accept_cargo("PETR"),produce_cargo("BOOM",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_EXPLOSIVES_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/farm.pnml
+++ b/src/industries/farm.pnml
@@ -929,7 +929,6 @@ if (param_extension_textile_industries && !param_extension_food_industries && !p
 			life_type: IND_LIFE_TYPE_ORGANIC;
 			min_cargo_distr: 1;
 			layouts: [farm_industry_layout_1_tilelayout,farm_industry_layout_2_tilelayout,farm_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_PLANT_FIELDS_PERIODICALLY,IND_FLAG_PLANT_FIELDS_WHEN_BUILT);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FARM;
@@ -940,6 +939,14 @@ if (param_extension_textile_industries && !param_extension_food_industries && !p
 			remove_cost_multiplier: 0;
 			cargo_types: [produce_cargo("LVST",0), produce_cargo("GRAI",0), produce_cargo("WOOL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FARM));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {
@@ -963,7 +970,6 @@ if (!param_extension_textile_industries && !param_extension_food_industries && !
 			life_type: IND_LIFE_TYPE_ORGANIC;
 			min_cargo_distr: 1;
 			layouts: [farm_industry_layout_1_tilelayout,farm_industry_layout_2_tilelayout,farm_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_PLANT_FIELDS_PERIODICALLY,IND_FLAG_PLANT_FIELDS_WHEN_BUILT);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FARM;
@@ -974,6 +980,14 @@ if (!param_extension_textile_industries && !param_extension_food_industries && !
 			remove_cost_multiplier: 0;
 			cargo_types: [produce_cargo("LVST",0), produce_cargo("GRAI",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FARM));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {
@@ -997,7 +1011,6 @@ if (param_extension_food_industries && !param_extension_fruits && !param_extensi
 			life_type: IND_LIFE_TYPE_ORGANIC;
 			min_cargo_distr: 1;
 			layouts: [farm_industry_layout_4_tilelayout,farm_industry_layout_5_tilelayout,farm_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_PLANT_FIELDS_PERIODICALLY,IND_FLAG_PLANT_FIELDS_WHEN_BUILT);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FARM;
@@ -1008,6 +1021,14 @@ if (param_extension_food_industries && !param_extension_fruits && !param_extensi
 			remove_cost_multiplier: 0;
 			cargo_types: [produce_cargo("GRAI",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FARM));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {
@@ -1031,7 +1052,6 @@ if (param_extension_textile_industries && !param_extension_food_industries && pa
 			life_type: IND_LIFE_TYPE_ORGANIC;
 			min_cargo_distr: 1;
 			layouts: [farm_industry_layout_1_tilelayout,farm_industry_layout_2_tilelayout,farm_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_PLANT_FIELDS_PERIODICALLY,IND_FLAG_PLANT_FIELDS_WHEN_BUILT);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FARM;
@@ -1042,6 +1062,14 @@ if (param_extension_textile_industries && !param_extension_food_industries && pa
 			remove_cost_multiplier: 0;
 			cargo_types: [produce_cargo("LVST",0), produce_cargo("GRAI",0), produce_cargo("WOOL",0),produce_cargo("BIOM",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FARM));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {
@@ -1065,7 +1093,6 @@ if (!param_extension_textile_industries && !param_extension_food_industries && p
 			life_type: IND_LIFE_TYPE_ORGANIC;
 			min_cargo_distr: 1;
 			layouts: [farm_industry_layout_1_tilelayout,farm_industry_layout_2_tilelayout,farm_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_PLANT_FIELDS_PERIODICALLY,IND_FLAG_PLANT_FIELDS_WHEN_BUILT);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FARM;
@@ -1076,6 +1103,14 @@ if (!param_extension_textile_industries && !param_extension_food_industries && p
 			remove_cost_multiplier: 0;
 			cargo_types: [produce_cargo("LVST",0), produce_cargo("GRAI",0),produce_cargo("BIOM",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FARM));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {
@@ -1099,7 +1134,6 @@ if (param_extension_food_industries && param_extension_fruits && !param_extensio
 			life_type: IND_LIFE_TYPE_ORGANIC;
 			min_cargo_distr: 1;
 			layouts: [farm_industry_layout_4_tilelayout,farm_industry_layout_5_tilelayout,farm_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_PLANT_FIELDS_PERIODICALLY,IND_FLAG_PLANT_FIELDS_WHEN_BUILT);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FARM;
@@ -1110,6 +1144,14 @@ if (param_extension_food_industries && param_extension_fruits && !param_extensio
 			remove_cost_multiplier: 0;
 			cargo_types: [produce_cargo("GRAI",0),produce_cargo("BIOM",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FARM));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {
@@ -1133,7 +1175,6 @@ if (param_extension_textile_industries && !param_extension_food_industries && !p
 			life_type: IND_LIFE_TYPE_ORGANIC;
 			min_cargo_distr: 1;
 			layouts: [farm_industry_layout_1_tilelayout,farm_industry_layout_2_tilelayout,farm_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_PLANT_FIELDS_PERIODICALLY,IND_FLAG_PLANT_FIELDS_WHEN_BUILT);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FARM;
@@ -1144,6 +1185,14 @@ if (param_extension_textile_industries && !param_extension_food_industries && !p
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FERT"),produce_cargo("LVST",0), produce_cargo("GRAI",0), produce_cargo("WOOL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FARM));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {
@@ -1169,7 +1218,6 @@ if (!param_extension_textile_industries && !param_extension_food_industries && !
 			life_type: IND_LIFE_TYPE_ORGANIC;
 			min_cargo_distr: 1;
 			layouts: [farm_industry_layout_1_tilelayout,farm_industry_layout_2_tilelayout,farm_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_PLANT_FIELDS_PERIODICALLY,IND_FLAG_PLANT_FIELDS_WHEN_BUILT);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FARM;
@@ -1180,6 +1228,14 @@ if (!param_extension_textile_industries && !param_extension_food_industries && !
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FERT"),produce_cargo("LVST",0), produce_cargo("GRAI",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FARM));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {
@@ -1205,7 +1261,6 @@ if (param_extension_food_industries && !param_extension_fruits && param_extensio
 			life_type: IND_LIFE_TYPE_ORGANIC;
 			min_cargo_distr: 1;
 			layouts: [farm_industry_layout_4_tilelayout,farm_industry_layout_5_tilelayout,farm_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_PLANT_FIELDS_PERIODICALLY,IND_FLAG_PLANT_FIELDS_WHEN_BUILT);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FARM;
@@ -1216,6 +1271,14 @@ if (param_extension_food_industries && !param_extension_fruits && param_extensio
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FERT"),produce_cargo("GRAI",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FARM));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {
@@ -1241,7 +1304,6 @@ if (param_extension_textile_industries && !param_extension_food_industries && pa
 			life_type: IND_LIFE_TYPE_ORGANIC;
 			min_cargo_distr: 1;
 			layouts: [farm_industry_layout_1_tilelayout,farm_industry_layout_2_tilelayout,farm_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_PLANT_FIELDS_PERIODICALLY,IND_FLAG_PLANT_FIELDS_WHEN_BUILT);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FARM;
@@ -1252,6 +1314,14 @@ if (param_extension_textile_industries && !param_extension_food_industries && pa
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FERT"),produce_cargo("LVST",0), produce_cargo("GRAI",0), produce_cargo("WOOL",0),produce_cargo("BIOM",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FARM));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {
@@ -1277,7 +1347,6 @@ if (!param_extension_textile_industries && !param_extension_food_industries && p
 			life_type: IND_LIFE_TYPE_ORGANIC;
 			min_cargo_distr: 1;
 			layouts: [farm_industry_layout_1_tilelayout,farm_industry_layout_2_tilelayout,farm_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_PLANT_FIELDS_PERIODICALLY,IND_FLAG_PLANT_FIELDS_WHEN_BUILT);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FARM;
@@ -1288,6 +1357,14 @@ if (!param_extension_textile_industries && !param_extension_food_industries && p
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FERT"),produce_cargo("LVST",0), produce_cargo("GRAI",0),produce_cargo("BIOM",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FARM));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {
@@ -1313,7 +1390,6 @@ if (param_extension_food_industries && param_extension_fruits && param_extension
 			life_type: IND_LIFE_TYPE_ORGANIC;
 			min_cargo_distr: 1;
 			layouts: [farm_industry_layout_4_tilelayout,farm_industry_layout_5_tilelayout,farm_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_PLANT_FIELDS_PERIODICALLY,IND_FLAG_PLANT_FIELDS_WHEN_BUILT);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FARM;
@@ -1324,6 +1400,14 @@ if (param_extension_food_industries && param_extension_fruits && param_extension
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FERT"),produce_cargo("GRAI",0),produce_cargo("BIOM",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FARM));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_PLANT_FIELDS_PERIODICALLY, IND_FLAG_PLANT_FIELDS_WHEN_BUILT, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {

--- a/src/industries/fertilizer_plant.pnml
+++ b/src/industries/fertilizer_plant.pnml
@@ -1288,7 +1288,6 @@ if (param_extension_production_boost && !param_extension_glass) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [fertilizer_plant_tilelayout_1,fertilizer_plant_tilelayout_2,fertilizer_plant_tilelayout_3,fertilizer_plant_tilelayout_4,fertilizer_plant_tilelayout_5,fertilizer_plant_tilelayout_6,fertilizer_plant_tilelayout_7];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_FERTILIZER_PLANT);
@@ -1298,6 +1297,14 @@ if (param_extension_production_boost && !param_extension_glass) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("ACID"),accept_cargo("NH3_"),accept_cargo("NHNO"),accept_cargo("POTA"),produce_cargo("FERT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FERTILIZER_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1324,7 +1331,6 @@ if (param_extension_production_boost && param_extension_glass) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [fertilizer_plant_tilelayout_1,fertilizer_plant_tilelayout_2,fertilizer_plant_tilelayout_3,fertilizer_plant_tilelayout_4,fertilizer_plant_tilelayout_5,fertilizer_plant_tilelayout_6,fertilizer_plant_tilelayout_7];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_FERTILIZER_PLANT);
@@ -1334,6 +1340,14 @@ if (param_extension_production_boost && param_extension_glass) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("ACID"),accept_cargo("NH3_"),accept_cargo("NHNO"),accept_cargo("POTA"),accept_cargo("QLME"),produce_cargo("FERT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FERTILIZER_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/fishing_grounds.pnml
+++ b/src/industries/fishing_grounds.pnml
@@ -284,7 +284,6 @@ item(FEAT_INDUSTRIES, fishing_grounds, INDUSTRY_ID_FISHING_GROUNDS) {
 		life_type: IND_LIFE_TYPE_ORGANIC;
 		min_cargo_distr: 1;
 		layouts: [fishing_grounds_industry_layout_1_tilelayout,fishing_grounds_industry_layout_2_tilelayout,fishing_grounds_industry_layout_3_tilelayout,fishing_grounds_industry_layout_4_tilelayout];
-		spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER,IND_FLAG_AI_CREATES_AIR_AND_SHIP_ROUTES);
 		conflicting_ind_types: [];
 		random_sound_effects: [];
 		name: string(STR_IND_FISHING_GROUNDS);
@@ -296,6 +295,14 @@ item(FEAT_INDUSTRIES, fishing_grounds, INDUSTRY_ID_FISHING_GROUNDS) {
 		cargo_types: [produce_cargo("FISH",0)];
 		nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FISHING_GROUNDS));
 	}
+	if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_AI_CREATES_AIR_AND_SHIP_ROUTES); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_AI_CREATES_AIR_AND_SHIP_ROUTES, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
+		}
 
 	graphics {
 		construction_probability: get_construction_probability;

--- a/src/industries/flour_mill.pnml
+++ b/src/industries/flour_mill.pnml
@@ -1132,7 +1132,6 @@ if (param_extension_food_industries && !param_extension_packaging_industries) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [flour_mill_tilelayout_1,flour_mill_tilelayout_2,flour_mill_tilelayout_3,flour_mill_tilelayout_4,flour_mill_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_FLOUR_MILL);
@@ -1142,6 +1141,14 @@ if (param_extension_food_industries && !param_extension_packaging_industries) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GRAI"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FLOUR_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1167,7 +1174,6 @@ if (param_extension_food_industries && param_extension_packaging_industries) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [flour_mill_tilelayout_1,flour_mill_tilelayout_2,flour_mill_tilelayout_3,flour_mill_tilelayout_4,flour_mill_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_FLOUR_MILL);
@@ -1177,6 +1183,14 @@ if (param_extension_food_industries && param_extension_packaging_industries) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GRAI"),accept_cargo("MNSP"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FLOUR_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/food_processor.pnml
+++ b/src/industries/food_processor.pnml
@@ -1224,7 +1224,6 @@ if (!param_extension_basic_inorganic_chemistry && !param_extension_food_industri
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [food_processor_industry_layout_1_tilelayout,food_processor_industry_layout_2_tilelayout,food_processor_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FOOD_PROCESSING_PLANT;
@@ -1234,6 +1233,14 @@ if (!param_extension_basic_inorganic_chemistry && !param_extension_food_industri
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("LVST"),accept_cargo("GRAI"),accept_cargo("FISH"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FOOD_PROCESSOR));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1259,7 +1266,6 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_food_industrie
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [food_processor_industry_layout_1_tilelayout,food_processor_industry_layout_2_tilelayout,food_processor_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FOOD_PROCESSING_PLANT;
@@ -1269,6 +1275,14 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_food_industrie
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("LVST"),accept_cargo("GRAI"),accept_cargo("FISH"),accept_cargo("SALT"),accept_cargo("LYE_"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FOOD_PROCESSOR));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1294,7 +1308,6 @@ if (!param_extension_basic_inorganic_chemistry && param_extension_food_industrie
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [food_processor_industry_layout_1_tilelayout,food_processor_industry_layout_2_tilelayout,food_processor_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FOOD_PROCESSING_PLANT;
@@ -1304,6 +1317,14 @@ if (!param_extension_basic_inorganic_chemistry && param_extension_food_industrie
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FISH"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FOOD_PROCESSOR));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1329,7 +1350,6 @@ if (param_extension_basic_inorganic_chemistry && param_extension_food_industries
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [food_processor_industry_layout_1_tilelayout,food_processor_industry_layout_2_tilelayout,food_processor_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FOOD_PROCESSING_PLANT;
@@ -1339,6 +1359,14 @@ if (param_extension_basic_inorganic_chemistry && param_extension_food_industries
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FISH"),accept_cargo("SALT"),accept_cargo("LYE_"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FOOD_PROCESSOR));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1364,7 +1392,6 @@ if (!param_extension_basic_inorganic_chemistry && !param_extension_food_industri
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [food_processor_industry_layout_1_tilelayout,food_processor_industry_layout_2_tilelayout,food_processor_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FOOD_PROCESSING_PLANT;
@@ -1374,6 +1401,14 @@ if (!param_extension_basic_inorganic_chemistry && !param_extension_food_industri
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("LVST"),accept_cargo("GRAI"),accept_cargo("FISH"),accept_cargo("MNSP"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FOOD_PROCESSOR));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1399,7 +1434,6 @@ if (!param_extension_basic_inorganic_chemistry && param_extension_food_industrie
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [food_processor_industry_layout_1_tilelayout,food_processor_industry_layout_2_tilelayout,food_processor_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FOOD_PROCESSING_PLANT;
@@ -1409,6 +1443,14 @@ if (!param_extension_basic_inorganic_chemistry && param_extension_food_industrie
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FISH"),accept_cargo("MNSP"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FOOD_PROCESSOR));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1434,7 +1476,6 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_food_industrie
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [food_processor_industry_layout_1_tilelayout,food_processor_industry_layout_2_tilelayout,food_processor_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FOOD_PROCESSING_PLANT;
@@ -1444,6 +1485,14 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_food_industrie
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("LVST"),accept_cargo("GRAI"),accept_cargo("FISH"),accept_cargo("SALT"),accept_cargo("LYE_"),accept_cargo("MNSP"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FOOD_PROCESSOR));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1468,7 +1517,6 @@ if (param_extension_basic_inorganic_chemistry && param_extension_food_industries
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [food_processor_industry_layout_1_tilelayout,food_processor_industry_layout_2_tilelayout,food_processor_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FOOD_PROCESSING_PLANT;
@@ -1478,6 +1526,14 @@ if (param_extension_basic_inorganic_chemistry && param_extension_food_industries
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FISH"),accept_cargo("SALT"),accept_cargo("LYE_"),accept_cargo("MNSP"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FOOD_PROCESSOR));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1503,7 +1559,6 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_food_industrie
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [food_processor_industry_layout_1_tilelayout,food_processor_industry_layout_2_tilelayout,food_processor_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FOOD_PROCESSING_PLANT;
@@ -1513,6 +1568,14 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_food_industrie
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FRUT"),accept_cargo("LVST"),accept_cargo("GRAI"),accept_cargo("FISH"),accept_cargo("SALT"),accept_cargo("LYE_"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FOOD_PROCESSOR));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1538,7 +1601,6 @@ if (param_extension_basic_inorganic_chemistry && param_extension_food_industries
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [food_processor_industry_layout_1_tilelayout,food_processor_industry_layout_2_tilelayout,food_processor_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FOOD_PROCESSING_PLANT;
@@ -1548,6 +1610,14 @@ if (param_extension_basic_inorganic_chemistry && param_extension_food_industries
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FRUT"),accept_cargo("FISH"),accept_cargo("SALT"),accept_cargo("LYE_"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FOOD_PROCESSOR));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1573,7 +1643,6 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_food_industrie
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [food_processor_industry_layout_1_tilelayout,food_processor_industry_layout_2_tilelayout,food_processor_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FOOD_PROCESSING_PLANT;
@@ -1583,6 +1652,14 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_food_industrie
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FRUT"),accept_cargo("LVST"),accept_cargo("GRAI"),accept_cargo("FISH"),accept_cargo("SALT"),accept_cargo("LYE_"),accept_cargo("MNSP"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FOOD_PROCESSOR));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1607,7 +1684,6 @@ if (param_extension_basic_inorganic_chemistry && param_extension_food_industries
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [food_processor_industry_layout_1_tilelayout,food_processor_industry_layout_2_tilelayout,food_processor_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FOOD_PROCESSING_PLANT;
@@ -1617,6 +1693,14 @@ if (param_extension_basic_inorganic_chemistry && param_extension_food_industries
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FRUT"),accept_cargo("FISH"),accept_cargo("SALT"),accept_cargo("LYE_"),accept_cargo("MNSP"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FOOD_PROCESSOR));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/forest.pnml
+++ b/src/industries/forest.pnml
@@ -5141,7 +5141,6 @@ if (!param_extension_production_boost) {
 			life_type: IND_LIFE_TYPE_ORGANIC;
 			min_cargo_distr: 1;
 			layouts: [forest_layout_1_tilelayout,forest_layout_2_tilelayout,forest_layout_3_tilelayout,forest_layout_4_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FOREST;
@@ -5152,6 +5151,14 @@ if (!param_extension_production_boost) {
 			remove_cost_multiplier: 0;
 			cargo_types: [produce_cargo("WOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FOREST));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 
 		graphics {
@@ -5175,7 +5182,6 @@ if (param_extension_production_boost) {
 			life_type: IND_LIFE_TYPE_ORGANIC;
 			min_cargo_distr: 1;
 			layouts: [forest_layout_1_tilelayout,forest_layout_2_tilelayout,forest_layout_3_tilelayout,forest_layout_4_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_FOREST;
@@ -5186,6 +5192,14 @@ if (param_extension_production_boost) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FERT"),produce_cargo("WOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FOREST));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 
 		graphics {

--- a/src/industries/foundry_forge.pnml
+++ b/src/industries/foundry_forge.pnml
@@ -454,7 +454,6 @@ if (param_extension_metallurgy && !param_extension_aluminium && !param_extension
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [foundry_forge_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_FOUNDRY_FORGE);
@@ -464,6 +463,14 @@ if (param_extension_metallurgy && !param_extension_aluminium && !param_extension
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("STEL"),produce_cargo("ENSP",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FOUNDRY_FORGE));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -490,7 +497,6 @@ if (param_extension_metallurgy && param_extension_aluminium && !param_extension_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [foundry_forge_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_FOUNDRY_FORGE);
@@ -500,6 +506,14 @@ if (param_extension_metallurgy && param_extension_aluminium && !param_extension_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("STEL"),accept_cargo("ALUM"),produce_cargo("ENSP",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FOUNDRY_FORGE));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -526,7 +540,6 @@ if (param_extension_metallurgy && !param_extension_aluminium && param_extension_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [foundry_forge_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_FOUNDRY_FORGE);
@@ -536,6 +549,14 @@ if (param_extension_metallurgy && !param_extension_aluminium && param_extension_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("STEL"),produce_cargo("ENSP",0),produce_cargo("SCMT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FOUNDRY_FORGE));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -562,7 +583,6 @@ if (param_extension_metallurgy && param_extension_aluminium && param_extension_r
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [foundry_forge_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_FOUNDRY_FORGE);
@@ -572,6 +592,14 @@ if (param_extension_metallurgy && param_extension_aluminium && param_extension_r
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("STEL"),accept_cargo("ALUM"),produce_cargo("ENSP",0),produce_cargo("SCMT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FOUNDRY_FORGE));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/fruit_plantation.pnml
+++ b/src/industries/fruit_plantation.pnml
@@ -2251,7 +2251,6 @@ if (param_extension_fruits && !param_extension_production_boost) {
 			life_type: IND_LIFE_TYPE_ORGANIC;
 			min_cargo_distr: 1;
 			layouts: [fruit_plantation_industry_layout_1_tilelayout,fruit_plantation_industry_layout_2_tilelayout,fruit_plantation_industry_layout_3_tilelayout,fruit_plantation_industry_layout_4_tilelayout,fruit_plantation_industry_layout_5_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_FRUIT_PLANTATION);
@@ -2262,6 +2261,14 @@ if (param_extension_fruits && !param_extension_production_boost) {
 			remove_cost_multiplier: 0;
 			cargo_types: [produce_cargo("FRUT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FRUIT_PLANTATION));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {
@@ -2285,7 +2292,6 @@ if (param_extension_fruits && param_extension_production_boost) {
 			life_type: IND_LIFE_TYPE_ORGANIC;
 			min_cargo_distr: 1;
 			layouts: [fruit_plantation_industry_layout_1_tilelayout,fruit_plantation_industry_layout_2_tilelayout,fruit_plantation_industry_layout_3_tilelayout,fruit_plantation_industry_layout_4_tilelayout,fruit_plantation_industry_layout_5_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_FRUIT_PLANTATION);
@@ -2296,6 +2302,14 @@ if (param_extension_fruits && param_extension_production_boost) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FERT"),produce_cargo("FRUT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FRUIT_PLANTATION));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 	
 		graphics {

--- a/src/industries/furniture_factory.pnml
+++ b/src/industries/furniture_factory.pnml
@@ -889,7 +889,6 @@ if (param_extension_textile_industries && !param_extension_packaging_industries)
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [furniture_factory_tilelayout_1,furniture_factory_tilelayout_2,furniture_factory_tilelayout_3,furniture_factory_tilelayout_4,furniture_factory_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_FURNITURE_FACTORY);
@@ -899,6 +898,14 @@ if (param_extension_textile_industries && !param_extension_packaging_industries)
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("WDPR"),accept_cargo("PLAS"),accept_cargo("TEXT"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FURNITURE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -924,7 +931,6 @@ if (!param_extension_textile_industries && !param_extension_packaging_industries
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [furniture_factory_tilelayout_1,furniture_factory_tilelayout_2,furniture_factory_tilelayout_3,furniture_factory_tilelayout_4,furniture_factory_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_FURNITURE_FACTORY);
@@ -934,6 +940,14 @@ if (!param_extension_textile_industries && !param_extension_packaging_industries
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("WDPR"),accept_cargo("PLAS"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FURNITURE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -959,7 +973,6 @@ if (param_extension_textile_industries && param_extension_packaging_industries) 
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [furniture_factory_tilelayout_1,furniture_factory_tilelayout_2,furniture_factory_tilelayout_3,furniture_factory_tilelayout_4,furniture_factory_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_FURNITURE_FACTORY);
@@ -969,6 +982,14 @@ if (param_extension_textile_industries && param_extension_packaging_industries) 
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("WDPR"),accept_cargo("PLAS"),accept_cargo("TEXT"),accept_cargo("MNSP"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FURNITURE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -994,7 +1015,6 @@ if (!param_extension_textile_industries && param_extension_packaging_industries)
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [furniture_factory_tilelayout_1,furniture_factory_tilelayout_2,furniture_factory_tilelayout_3,furniture_factory_tilelayout_4,furniture_factory_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_FURNITURE_FACTORY);
@@ -1004,6 +1024,14 @@ if (!param_extension_textile_industries && param_extension_packaging_industries)
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("WDPR"),accept_cargo("PLAS"),accept_cargo("MNSP"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_FURNITURE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/general_store.pnml
+++ b/src/industries/general_store.pnml
@@ -179,7 +179,6 @@ if (!param_extension_fruits) {
 			life_type: IND_LIFE_TYPE_BLACK_HOLE;
 			min_cargo_distr: 1;
 			layouts: [general_store_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_ONLY_IN_TOWNS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_GENERAL_STORE);
@@ -190,6 +189,14 @@ if (!param_extension_fruits) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FOOD")];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_GENERAL_STORE));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ONLY_IN_TOWNS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ONLY_IN_TOWNS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -213,7 +220,6 @@ if (param_extension_fruits) {
 			life_type: IND_LIFE_TYPE_BLACK_HOLE;
 			min_cargo_distr: 1;
 			layouts: [general_store_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_ONLY_IN_TOWNS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_GENERAL_STORE);
@@ -224,6 +230,14 @@ if (param_extension_fruits) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FOOD"),accept_cargo("FRUT")];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_GENERAL_STORE));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ONLY_IN_TOWNS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ONLY_IN_TOWNS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/glass_works.pnml
+++ b/src/industries/glass_works.pnml
@@ -1170,7 +1170,6 @@ if (param_extension_glass && !param_extension_ammonia && !param_extension_recycl
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [glass_works_tilelayout_1, glass_works_tilelayout_2, glass_works_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_GLASS_WORKS);
@@ -1180,6 +1179,14 @@ if (param_extension_glass && !param_extension_ammonia && !param_extension_recycl
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SAND"),accept_cargo("QLME"),produce_cargo("GLAS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_GLASS_WORKS));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1205,7 +1212,6 @@ if (param_extension_glass && param_extension_ammonia && !param_extension_recycli
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [glass_works_tilelayout_1, glass_works_tilelayout_2, glass_works_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_GLASS_WORKS);
@@ -1215,6 +1221,14 @@ if (param_extension_glass && param_extension_ammonia && !param_extension_recycli
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SAND"),accept_cargo("QLME"),accept_cargo("SASH"),produce_cargo("GLAS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_GLASS_WORKS));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1241,7 +1255,6 @@ if (param_extension_glass && !param_extension_ammonia && param_extension_recycli
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [glass_works_tilelayout_1, glass_works_tilelayout_2, glass_works_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_GLASS_WORKS);
@@ -1251,6 +1264,14 @@ if (param_extension_glass && !param_extension_ammonia && param_extension_recycli
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SAND"),accept_cargo("QLME"),accept_cargo("RCYC"),produce_cargo("GLAS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_GLASS_WORKS));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1276,7 +1297,6 @@ if (param_extension_glass && param_extension_ammonia && param_extension_recyclin
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [glass_works_tilelayout_1, glass_works_tilelayout_2, glass_works_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_GLASS_WORKS);
@@ -1286,6 +1306,14 @@ if (param_extension_glass && param_extension_ammonia && param_extension_recyclin
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SAND"),accept_cargo("QLME"),accept_cargo("SASH"),accept_cargo("RCYC"),produce_cargo("GLAS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_GLASS_WORKS));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1311,7 +1339,6 @@ if (param_extension_glass && !param_extension_ammonia && !param_extension_recycl
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [glass_works_tilelayout_1, glass_works_tilelayout_2, glass_works_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_GLASS_WORKS);
@@ -1321,6 +1348,14 @@ if (param_extension_glass && !param_extension_ammonia && !param_extension_recycl
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SAND"),accept_cargo("QLME"),accept_cargo("POTA"),produce_cargo("GLAS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_GLASS_WORKS));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1346,7 +1381,6 @@ if (param_extension_glass && param_extension_ammonia && !param_extension_recycli
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [glass_works_tilelayout_1, glass_works_tilelayout_2, glass_works_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_GLASS_WORKS);
@@ -1356,6 +1390,14 @@ if (param_extension_glass && param_extension_ammonia && !param_extension_recycli
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SAND"),accept_cargo("QLME"),accept_cargo("SASH"),accept_cargo("POTA"),produce_cargo("GLAS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_GLASS_WORKS));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1382,7 +1424,6 @@ if (param_extension_glass && !param_extension_ammonia && param_extension_recycli
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [glass_works_tilelayout_1, glass_works_tilelayout_2, glass_works_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_GLASS_WORKS);
@@ -1392,6 +1433,14 @@ if (param_extension_glass && !param_extension_ammonia && param_extension_recycli
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SAND"),accept_cargo("QLME"),accept_cargo("RCYC"),accept_cargo("POTA"),produce_cargo("GLAS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_GLASS_WORKS));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1417,7 +1466,6 @@ if (param_extension_glass && param_extension_ammonia && param_extension_recyclin
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [glass_works_tilelayout_1, glass_works_tilelayout_2, glass_works_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_GLASS_WORKS);
@@ -1427,6 +1475,14 @@ if (param_extension_glass && param_extension_ammonia && param_extension_recyclin
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SAND"),accept_cargo("QLME"),accept_cargo("SASH"),accept_cargo("RCYC"),accept_cargo("POTA"),produce_cargo("GLAS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_GLASS_WORKS));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/hotel.pnml
+++ b/src/industries/hotel.pnml
@@ -461,7 +461,6 @@ if (!param_extension_fruits) {
 			life_type: IND_LIFE_TYPE_BLACK_HOLE;
 			min_cargo_distr: 1;
 			layouts: [hotel_tilelayout_pool_on_roof,hotel_tilelayout_small_bungalow,hotel_tilelayout_modern_1,hotel_tilelayout_modern_2,hotel_tilelayout_single_tile_1,hotel_tilelayout_single_tile_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_HOTEL);
@@ -472,6 +471,14 @@ if (!param_extension_fruits) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FOOD"),accept_cargo("PASS"),produce_cargo("PASS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_HOTEL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 
 		graphics {
@@ -495,7 +502,6 @@ if (param_extension_fruits) {
 			life_type: IND_LIFE_TYPE_BLACK_HOLE;
 			min_cargo_distr: 1;
 			layouts: [hotel_tilelayout_pool_on_roof,hotel_tilelayout_small_bungalow,hotel_tilelayout_modern_1,hotel_tilelayout_modern_2,hotel_tilelayout_single_tile_1,hotel_tilelayout_single_tile_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_HOTEL);
@@ -506,6 +512,14 @@ if (param_extension_fruits) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("FRUT"),accept_cargo("FOOD"),accept_cargo("PASS"),produce_cargo("PASS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_HOTEL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 
 		graphics {

--- a/src/industries/integrated_steel_mill.pnml
+++ b/src/industries/integrated_steel_mill.pnml
@@ -1530,7 +1530,6 @@ if (!param_extension_glass && !param_extension_coke_sulphur && !param_extension_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steel_mill_tilelayout_1, steel_mill_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_INTEGRATED_STEEL_MILL);
@@ -1540,6 +1539,14 @@ if (!param_extension_glass && !param_extension_coke_sulphur && !param_extension_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COAL"),accept_cargo("IORE"),produce_cargo("STEL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_INTEGRATED_STEEL_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1566,7 +1573,6 @@ if (param_extension_glass && !param_extension_coke_sulphur && !param_extension_a
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steel_mill_tilelayout_1, steel_mill_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_INTEGRATED_STEEL_MILL);
@@ -1576,6 +1582,14 @@ if (param_extension_glass && !param_extension_coke_sulphur && !param_extension_a
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COAL"),accept_cargo("IORE"),accept_cargo("QLME"),produce_cargo("STEL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_INTEGRATED_STEEL_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1602,7 +1616,6 @@ if (!param_extension_glass && param_extension_coke_sulphur && !param_extension_a
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steel_mill_tilelayout_1, steel_mill_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_INTEGRATED_STEEL_MILL);
@@ -1612,6 +1625,14 @@ if (!param_extension_glass && param_extension_coke_sulphur && !param_extension_a
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("IORE"),produce_cargo("STEL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_INTEGRATED_STEEL_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1638,7 +1659,6 @@ if (param_extension_glass && param_extension_coke_sulphur && !param_extension_am
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steel_mill_tilelayout_1, steel_mill_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_INTEGRATED_STEEL_MILL);
@@ -1648,6 +1668,14 @@ if (param_extension_glass && param_extension_coke_sulphur && !param_extension_am
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("IORE"),accept_cargo("QLME"),produce_cargo("STEL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_INTEGRATED_STEEL_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1674,7 +1702,6 @@ if (!param_extension_glass && !param_extension_coke_sulphur && param_extension_a
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steel_mill_tilelayout_1, steel_mill_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_INTEGRATED_STEEL_MILL);
@@ -1684,6 +1711,14 @@ if (!param_extension_glass && !param_extension_coke_sulphur && param_extension_a
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COAL"),accept_cargo("IORE"),accept_cargo("O2__"),produce_cargo("STEL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_INTEGRATED_STEEL_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1710,7 +1745,6 @@ if (param_extension_glass && !param_extension_coke_sulphur && param_extension_am
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steel_mill_tilelayout_1, steel_mill_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_INTEGRATED_STEEL_MILL);
@@ -1720,6 +1754,14 @@ if (param_extension_glass && !param_extension_coke_sulphur && param_extension_am
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COAL"),accept_cargo("IORE"),accept_cargo("QLME"),accept_cargo("O2__"),produce_cargo("STEL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_INTEGRATED_STEEL_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1746,7 +1788,6 @@ if (!param_extension_glass && param_extension_coke_sulphur && param_extension_am
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steel_mill_tilelayout_1, steel_mill_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_INTEGRATED_STEEL_MILL);
@@ -1756,6 +1797,14 @@ if (!param_extension_glass && param_extension_coke_sulphur && param_extension_am
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("IORE"),accept_cargo("O2__"),produce_cargo("STEL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_INTEGRATED_STEEL_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1782,7 +1831,6 @@ if (param_extension_glass && param_extension_coke_sulphur && param_extension_amm
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steel_mill_tilelayout_1, steel_mill_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_INTEGRATED_STEEL_MILL);
@@ -1792,6 +1840,14 @@ if (param_extension_glass && param_extension_coke_sulphur && param_extension_amm
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("IORE"),accept_cargo("QLME"),accept_cargo("O2__"),produce_cargo("STEL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_INTEGRATED_STEEL_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1818,7 +1874,6 @@ if (!param_extension_glass && !param_extension_coke_sulphur && !param_extension_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steel_mill_tilelayout_1, steel_mill_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_INTEGRATED_STEEL_MILL);
@@ -1828,6 +1883,14 @@ if (!param_extension_glass && !param_extension_coke_sulphur && !param_extension_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COAL"),accept_cargo("IORE"),accept_cargo("SCMT"),produce_cargo("STEL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_INTEGRATED_STEEL_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1854,7 +1917,6 @@ if (param_extension_glass && !param_extension_coke_sulphur && !param_extension_a
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steel_mill_tilelayout_1, steel_mill_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_INTEGRATED_STEEL_MILL);
@@ -1864,6 +1926,14 @@ if (param_extension_glass && !param_extension_coke_sulphur && !param_extension_a
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COAL"),accept_cargo("IORE"),accept_cargo("QLME"),accept_cargo("SCMT"),produce_cargo("STEL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_INTEGRATED_STEEL_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1890,7 +1960,6 @@ if (!param_extension_glass && param_extension_coke_sulphur && !param_extension_a
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steel_mill_tilelayout_1, steel_mill_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_INTEGRATED_STEEL_MILL);
@@ -1900,6 +1969,14 @@ if (!param_extension_glass && param_extension_coke_sulphur && !param_extension_a
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("IORE"),accept_cargo("SCMT"),produce_cargo("STEL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_INTEGRATED_STEEL_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1926,7 +2003,6 @@ if (param_extension_glass && param_extension_coke_sulphur && !param_extension_am
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steel_mill_tilelayout_1, steel_mill_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_INTEGRATED_STEEL_MILL);
@@ -1936,6 +2012,14 @@ if (param_extension_glass && param_extension_coke_sulphur && !param_extension_am
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("IORE"),accept_cargo("QLME"),accept_cargo("SCMT"),produce_cargo("STEL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_INTEGRATED_STEEL_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1962,7 +2046,6 @@ if (!param_extension_glass && !param_extension_coke_sulphur && param_extension_a
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steel_mill_tilelayout_1, steel_mill_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_INTEGRATED_STEEL_MILL);
@@ -1972,6 +2055,14 @@ if (!param_extension_glass && !param_extension_coke_sulphur && param_extension_a
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COAL"),accept_cargo("IORE"),accept_cargo("O2__"),accept_cargo("SCMT"),produce_cargo("STEL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_INTEGRATED_STEEL_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1998,7 +2089,6 @@ if (param_extension_glass && !param_extension_coke_sulphur && param_extension_am
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steel_mill_tilelayout_1, steel_mill_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_INTEGRATED_STEEL_MILL);
@@ -2008,6 +2098,14 @@ if (param_extension_glass && !param_extension_coke_sulphur && param_extension_am
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COAL"),accept_cargo("IORE"),accept_cargo("QLME"),accept_cargo("SCMT"),accept_cargo("O2__"),produce_cargo("STEL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_INTEGRATED_STEEL_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2034,7 +2132,6 @@ if (!param_extension_glass && param_extension_coke_sulphur && param_extension_am
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steel_mill_tilelayout_1, steel_mill_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_INTEGRATED_STEEL_MILL);
@@ -2044,6 +2141,14 @@ if (!param_extension_glass && param_extension_coke_sulphur && param_extension_am
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("IORE"),accept_cargo("O2__"),accept_cargo("SCMT"),produce_cargo("STEL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_INTEGRATED_STEEL_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2070,7 +2175,6 @@ if (param_extension_glass && param_extension_coke_sulphur && param_extension_amm
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steel_mill_tilelayout_1, steel_mill_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_INTEGRATED_STEEL_MILL);
@@ -2080,6 +2184,14 @@ if (param_extension_glass && param_extension_coke_sulphur && param_extension_amm
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("IORE"),accept_cargo("QLME"),accept_cargo("SCMT"),accept_cargo("O2__"),produce_cargo("STEL",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_INTEGRATED_STEEL_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/iron_ore_mine.pnml
+++ b/src/industries/iron_ore_mine.pnml
@@ -634,7 +634,7 @@ if (!param_extension_production_boost) {
 			life_type: IND_LIFE_TYPE_EXTRACTIVE;
 			min_cargo_distr: 1;
 			layouts: [iron_ore_mine_industry_layout_1_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
+			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_IRON_ORE_MINE;
@@ -668,7 +668,7 @@ if (param_extension_production_boost) {
 			life_type: IND_LIFE_TYPE_EXTRACTIVE;
 			min_cargo_distr: 1;
 			layouts: [iron_ore_mine_industry_layout_1_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
+			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_IRON_ORE_MINE;

--- a/src/industries/lime_kiln.pnml
+++ b/src/industries/lime_kiln.pnml
@@ -795,7 +795,6 @@ if (param_extension_glass && !param_extension_coke_sulphur) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [lime_kiln_tilelayout_1, lime_kiln_tilelayout_2, lime_kiln_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_LIME_KILN);
@@ -805,6 +804,14 @@ if (param_extension_glass && !param_extension_coke_sulphur) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("LIME"),produce_cargo("QLME",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_LIME_KILN));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -830,7 +837,6 @@ if (param_extension_glass && param_extension_coke_sulphur) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [lime_kiln_tilelayout_1, lime_kiln_tilelayout_2, lime_kiln_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_LIME_KILN);
@@ -840,6 +846,14 @@ if (param_extension_glass && param_extension_coke_sulphur) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("LIME"),accept_cargo("COKE"),produce_cargo("QLME",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_LIME_KILN));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/limestone_mine.pnml
+++ b/src/industries/limestone_mine.pnml
@@ -662,7 +662,7 @@ item(FEAT_INDUSTRIES, limestone_mine, INDUSTRY_ID_LIMESTONE_MINE) {
 		life_type: IND_LIFE_TYPE_EXTRACTIVE;
 		min_cargo_distr: 1;
 		layouts: [limestone_mine_industry_layout_1_tilelayout,limestone_mine_industry_layout_2_tilelayout,limestone_mine_industry_layout_3_tilelayout,limestone_mine_industry_layout_4_tilelayout];
-		spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
+		spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 		conflicting_ind_types: [];
 		random_sound_effects: [];
 		name: string(STR_IND_LIMESTONE_MINE);
@@ -699,7 +699,7 @@ if (param_extension_building_materials && param_extension_production_boost) {
 			life_type: IND_LIFE_TYPE_EXTRACTIVE;
 			min_cargo_distr: 1;
 			layouts: [limestone_mine_industry_layout_1_tilelayout,limestone_mine_industry_layout_2_tilelayout,limestone_mine_industry_layout_3_tilelayout,limestone_mine_industry_layout_4_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
+			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_LIMESTONE_MINE);

--- a/src/industries/oil_refinery.pnml
+++ b/src/industries/oil_refinery.pnml
@@ -715,7 +715,6 @@ if (param_extension_organic_chemistry && !param_extension_coke_sulphur) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [oil_refinery_tilelayout_1,oil_refinery_tilelayout_2,oil_refinery_tilelayout_3,oil_refinery_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_OIL_REFINERY;
@@ -725,6 +724,14 @@ if (param_extension_organic_chemistry && !param_extension_coke_sulphur) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("OIL_"),produce_cargo("RFPR",0),produce_cargo("PETR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_OIL_REFINERY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -751,7 +758,6 @@ if (param_extension_organic_chemistry && param_extension_coke_sulphur) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [oil_refinery_tilelayout_1,oil_refinery_tilelayout_2,oil_refinery_tilelayout_3,oil_refinery_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_OIL_REFINERY;
@@ -761,6 +767,14 @@ if (param_extension_organic_chemistry && param_extension_coke_sulphur) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("OIL_"),produce_cargo("RFPR",0),produce_cargo("PETR",0),produce_cargo("SULP",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_OIL_REFINERY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/oil_rig.pnml
+++ b/src/industries/oil_rig.pnml
@@ -525,7 +525,7 @@ if (!param_extension_production_boost) {
 			life_type: IND_LIFE_TYPE_EXTRACTIVE;
 			min_cargo_distr: 1;
 			layouts: [oil_rig_layout_1_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER,IND_FLAG_AI_CREATES_AIR_AND_SHIP_ROUTES);
+			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_AI_CREATES_AIR_AND_SHIP_ROUTES, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_OIL_RIG;
@@ -561,7 +561,7 @@ if (param_extension_production_boost) {
 			life_type: IND_LIFE_TYPE_EXTRACTIVE;
 			min_cargo_distr: 1;
 			layouts: [oil_rig_layout_1_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER,IND_FLAG_AI_CREATES_AIR_AND_SHIP_ROUTES);
+			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_AI_CREATES_AIR_AND_SHIP_ROUTES, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_OIL_RIG;

--- a/src/industries/oil_well.pnml
+++ b/src/industries/oil_well.pnml
@@ -501,7 +501,7 @@ item(FEAT_INDUSTRIES, oil_well, INDUSTRY_ID_OIL_WELL) {
 		life_type: IND_LIFE_TYPE_EXTRACTIVE;
 		min_cargo_distr: 1;
 		layouts: [oil_well_industry_layout_1_tilelayout,oil_well_industry_layout_2_tilelayout,oil_well_industry_layout_3_tilelayout,oil_well_industry_layout_4_tilelayout];
-		spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
+		spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 		conflicting_ind_types: [];
 		random_sound_effects: [];
 		name: TTD_STR_INDUSTRY_NAME_OIL_WELLS;

--- a/src/industries/ore_smelter.pnml
+++ b/src/industries/ore_smelter.pnml
@@ -1292,7 +1292,6 @@ if (param_extension_coke_sulphur && !param_extension_painting_industries && !par
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [ore_smelter_tilelayout_1, ore_smelter_tilelayout_2, ore_smelter_tilelayout_3, ore_smelter_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ORE_SMELTER);
@@ -1302,6 +1301,14 @@ if (param_extension_coke_sulphur && !param_extension_painting_industries && !par
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("PORE"),produce_cargo("IORE",0),produce_cargo("SULP",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ORE_SMELTER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1328,7 +1335,6 @@ if (param_extension_coke_sulphur && param_extension_painting_industries && !para
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [ore_smelter_tilelayout_1, ore_smelter_tilelayout_2, ore_smelter_tilelayout_3, ore_smelter_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ORE_SMELTER);
@@ -1338,6 +1344,14 @@ if (param_extension_coke_sulphur && param_extension_painting_industries && !para
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("PORE"),produce_cargo("IORE",0),produce_cargo("SULP",0),produce_cargo("CORE",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ORE_SMELTER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1364,7 +1378,6 @@ if (param_extension_coke_sulphur && !param_extension_painting_industries && para
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [ore_smelter_tilelayout_1, ore_smelter_tilelayout_2, ore_smelter_tilelayout_3, ore_smelter_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ORE_SMELTER);
@@ -1374,6 +1387,14 @@ if (param_extension_coke_sulphur && !param_extension_painting_industries && para
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("PORE"),accept_cargo("O2__"),produce_cargo("IORE",0),produce_cargo("SULP",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ORE_SMELTER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1400,7 +1421,6 @@ if (param_extension_coke_sulphur && param_extension_painting_industries && param
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [ore_smelter_tilelayout_1, ore_smelter_tilelayout_2, ore_smelter_tilelayout_3, ore_smelter_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ORE_SMELTER);
@@ -1410,6 +1430,14 @@ if (param_extension_coke_sulphur && param_extension_painting_industries && param
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("PORE"),accept_cargo("O2__"),produce_cargo("IORE",0),produce_cargo("SULP",0),produce_cargo("CORE",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ORE_SMELTER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1435,7 +1463,6 @@ if (param_extension_coke_sulphur && !param_extension_painting_industries && !par
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [ore_smelter_tilelayout_1, ore_smelter_tilelayout_2, ore_smelter_tilelayout_3, ore_smelter_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ORE_SMELTER);
@@ -1445,6 +1472,14 @@ if (param_extension_coke_sulphur && !param_extension_painting_industries && !par
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("PORE"),produce_cargo("IORE",0),produce_cargo("SULP",0),produce_cargo("ZINC",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ORE_SMELTER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1471,7 +1506,6 @@ if (param_extension_coke_sulphur && param_extension_painting_industries && !para
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [ore_smelter_tilelayout_1, ore_smelter_tilelayout_2, ore_smelter_tilelayout_3, ore_smelter_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ORE_SMELTER);
@@ -1481,6 +1515,14 @@ if (param_extension_coke_sulphur && param_extension_painting_industries && !para
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("PORE"),produce_cargo("IORE",0),produce_cargo("SULP",0),produce_cargo("CORE",0),produce_cargo("ZINC",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ORE_SMELTER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1507,7 +1549,6 @@ if (param_extension_coke_sulphur && !param_extension_painting_industries && para
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [ore_smelter_tilelayout_1, ore_smelter_tilelayout_2, ore_smelter_tilelayout_3, ore_smelter_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ORE_SMELTER);
@@ -1517,6 +1558,14 @@ if (param_extension_coke_sulphur && !param_extension_painting_industries && para
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("PORE"),accept_cargo("O2__"),produce_cargo("IORE",0),produce_cargo("SULP",0),produce_cargo("ZINC",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ORE_SMELTER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1543,7 +1592,6 @@ if (param_extension_coke_sulphur && param_extension_painting_industries && param
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [ore_smelter_tilelayout_1, ore_smelter_tilelayout_2, ore_smelter_tilelayout_3, ore_smelter_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_ORE_SMELTER);
@@ -1553,6 +1601,14 @@ if (param_extension_coke_sulphur && param_extension_painting_industries && param
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COKE"),accept_cargo("PORE"),accept_cargo("O2__"),produce_cargo("IORE",0),produce_cargo("SULP",0),produce_cargo("CORE",0),produce_cargo("ZINC",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_ORE_SMELTER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/packaging_plant.pnml
+++ b/src/industries/packaging_plant.pnml
@@ -1124,7 +1124,6 @@ if (param_extension_packaging_industries && !param_extension_aluminium && !param
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [packaging_plant_industry_layout_1_tilelayout,packaging_plant_industry_layout_2_tilelayout,packaging_plant_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PACKAGING_PLANT);
@@ -1134,6 +1133,14 @@ if (param_extension_packaging_industries && !param_extension_aluminium && !param
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),produce_cargo("MNSP",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PACKAGING_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1160,7 +1167,6 @@ if (param_extension_packaging_industries && param_extension_aluminium && !param_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [packaging_plant_industry_layout_1_tilelayout,packaging_plant_industry_layout_2_tilelayout,packaging_plant_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PACKAGING_PLANT);
@@ -1170,6 +1176,14 @@ if (param_extension_packaging_industries && param_extension_aluminium && !param_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("ALUM"),produce_cargo("MNSP",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PACKAGING_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1196,7 +1210,6 @@ if (param_extension_packaging_industries && !param_extension_aluminium && param_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [packaging_plant_industry_layout_1_tilelayout,packaging_plant_industry_layout_2_tilelayout,packaging_plant_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PACKAGING_PLANT);
@@ -1206,6 +1219,14 @@ if (param_extension_packaging_industries && !param_extension_aluminium && param_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("GLAS"),produce_cargo("MNSP",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PACKAGING_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1232,7 +1253,6 @@ if (param_extension_packaging_industries && param_extension_aluminium && param_e
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [packaging_plant_industry_layout_1_tilelayout,packaging_plant_industry_layout_2_tilelayout,packaging_plant_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PACKAGING_PLANT);
@@ -1242,6 +1262,14 @@ if (param_extension_packaging_industries && param_extension_aluminium && param_e
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("ALUM"),accept_cargo("GLAS"),produce_cargo("MNSP",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PACKAGING_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1268,7 +1296,6 @@ if (param_extension_packaging_industries && !param_extension_aluminium && !param
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [packaging_plant_industry_layout_1_tilelayout,packaging_plant_industry_layout_2_tilelayout,packaging_plant_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PACKAGING_PLANT);
@@ -1278,6 +1305,14 @@ if (param_extension_packaging_industries && !param_extension_aluminium && !param
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("PAPR"),produce_cargo("MNSP",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PACKAGING_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1304,7 +1339,6 @@ if (param_extension_packaging_industries && param_extension_aluminium && !param_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [packaging_plant_industry_layout_1_tilelayout,packaging_plant_industry_layout_2_tilelayout,packaging_plant_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PACKAGING_PLANT);
@@ -1314,6 +1348,14 @@ if (param_extension_packaging_industries && param_extension_aluminium && !param_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("ALUM"),accept_cargo("PAPR"),produce_cargo("MNSP",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PACKAGING_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1340,7 +1382,6 @@ if (param_extension_packaging_industries && !param_extension_aluminium && param_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [packaging_plant_industry_layout_1_tilelayout,packaging_plant_industry_layout_2_tilelayout,packaging_plant_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PACKAGING_PLANT);
@@ -1350,6 +1391,14 @@ if (param_extension_packaging_industries && !param_extension_aluminium && param_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("PAPR"),accept_cargo("GLAS"),produce_cargo("MNSP",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PACKAGING_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1376,7 +1425,6 @@ if (param_extension_packaging_industries && param_extension_aluminium && param_e
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [packaging_plant_industry_layout_1_tilelayout,packaging_plant_industry_layout_2_tilelayout,packaging_plant_industry_layout_3_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PACKAGING_PLANT);
@@ -1386,6 +1434,14 @@ if (param_extension_packaging_industries && param_extension_aluminium && param_e
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("ALUM"),accept_cargo("GLAS"),accept_cargo("PAPR"),produce_cargo("MNSP",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PACKAGING_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/paint_factory.pnml
+++ b/src/industries/paint_factory.pnml
@@ -869,7 +869,6 @@ if (param_extension_painting_industries && !param_extension_building_materials &
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [paint_factory_tilelayout_1,paint_factory_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PAINT_FACTORY);
@@ -879,6 +878,14 @@ if (param_extension_painting_industries && !param_extension_building_materials &
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("IORE"),accept_cargo("COPR"),accept_cargo("CBLK"),produce_cargo("COAT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PAINT_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -904,7 +911,6 @@ if (param_extension_painting_industries && param_extension_building_materials &&
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [paint_factory_tilelayout_1,paint_factory_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PAINT_FACTORY);
@@ -914,6 +920,14 @@ if (param_extension_painting_industries && param_extension_building_materials &&
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("IORE"),accept_cargo("COPR"),accept_cargo("CBLK"),accept_cargo("LIME"),produce_cargo("COAT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PAINT_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -940,7 +954,6 @@ if (param_extension_painting_industries && !param_extension_building_materials &
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [paint_factory_tilelayout_1,paint_factory_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PAINT_FACTORY);
@@ -950,6 +963,14 @@ if (param_extension_painting_industries && !param_extension_building_materials &
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("IORE"),accept_cargo("COPR"),accept_cargo("CBLK"),accept_cargo("ACID"),produce_cargo("COAT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PAINT_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -975,7 +996,6 @@ if (param_extension_painting_industries && param_extension_building_materials &&
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [paint_factory_tilelayout_1,paint_factory_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PAINT_FACTORY);
@@ -985,6 +1005,14 @@ if (param_extension_painting_industries && param_extension_building_materials &&
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("IORE"),accept_cargo("COPR"),accept_cargo("CBLK"),accept_cargo("LIME"),accept_cargo("ACID"),produce_cargo("COAT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PAINT_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/paper_mill.pnml
+++ b/src/industries/paper_mill.pnml
@@ -1063,7 +1063,6 @@ if (param_extension_paper && !param_extension_recycling) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [paper_mill_tilelayout_1, paper_mill_tilelayout_2, paper_mill_tilelayout_3, paper_mill_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_PAPER_MILL;
@@ -1073,6 +1072,14 @@ if (param_extension_paper && !param_extension_recycling) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("LYE_"),accept_cargo("CHLO"),accept_cargo("WOOD"),produce_cargo("PAPR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PAPER_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1100,7 +1107,6 @@ if (param_extension_paper && param_extension_recycling) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [paper_mill_tilelayout_1, paper_mill_tilelayout_2, paper_mill_tilelayout_3, paper_mill_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_PAPER_MILL;
@@ -1110,6 +1116,14 @@ if (param_extension_paper && param_extension_recycling) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("LYE_"),accept_cargo("CHLO"),accept_cargo("WOOD"),accept_cargo("RCYC"),produce_cargo("PAPR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PAPER_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/petrol_station.pnml
+++ b/src/industries/petrol_station.pnml
@@ -206,7 +206,6 @@ if (param_extension_organic_chemistry) {
 			life_type: IND_LIFE_TYPE_BLACK_HOLE;
 			min_cargo_distr: 1;
 			layouts: [petrol_station_tilelayout_1, petrol_station_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_ONLY_IN_TOWNS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PETROL_STATION);
@@ -217,6 +216,14 @@ if (param_extension_organic_chemistry) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PETR")];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PETROL_STATION));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ONLY_IN_TOWNS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ONLY_IN_TOWNS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/pharmaceutical_plant.pnml
+++ b/src/industries/pharmaceutical_plant.pnml
@@ -1847,7 +1847,6 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_packaging_indu
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [pharmaceutical_plant_industry_layout_1_tilelayout,pharmaceutical_plant_industry_layout_2_tilelayout,pharmaceutical_plant_industry_layout_3_tilelayout,pharmaceutical_plant_industry_layout_4_tilelayout,pharmaceutical_plant_industry_layout_5_tilelayout,pharmaceutical_plant_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PHARMACEUTICAL_PLANT);
@@ -1857,6 +1856,14 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_packaging_indu
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CHLO"),accept_cargo("H2__"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PHARMACEUTICAL_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1883,7 +1890,6 @@ if (param_extension_basic_inorganic_chemistry && param_extension_packaging_indus
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [pharmaceutical_plant_industry_layout_1_tilelayout,pharmaceutical_plant_industry_layout_2_tilelayout,pharmaceutical_plant_industry_layout_3_tilelayout,pharmaceutical_plant_industry_layout_4_tilelayout,pharmaceutical_plant_industry_layout_5_tilelayout,pharmaceutical_plant_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PHARMACEUTICAL_PLANT);
@@ -1893,6 +1899,14 @@ if (param_extension_basic_inorganic_chemistry && param_extension_packaging_indus
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CHLO"),accept_cargo("H2__"),accept_cargo("MNSP"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PHARMACEUTICAL_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1919,7 +1933,6 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_packaging_indu
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [pharmaceutical_plant_industry_layout_1_tilelayout,pharmaceutical_plant_industry_layout_2_tilelayout,pharmaceutical_plant_industry_layout_3_tilelayout,pharmaceutical_plant_industry_layout_4_tilelayout,pharmaceutical_plant_industry_layout_5_tilelayout,pharmaceutical_plant_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PHARMACEUTICAL_PLANT);
@@ -1929,6 +1942,14 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_packaging_indu
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CHLO"),accept_cargo("H2__"),accept_cargo("C2H4"),accept_cargo("RFPR"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PHARMACEUTICAL_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1955,7 +1976,6 @@ if (param_extension_basic_inorganic_chemistry && param_extension_packaging_indus
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [pharmaceutical_plant_industry_layout_1_tilelayout,pharmaceutical_plant_industry_layout_2_tilelayout,pharmaceutical_plant_industry_layout_3_tilelayout,pharmaceutical_plant_industry_layout_4_tilelayout,pharmaceutical_plant_industry_layout_5_tilelayout,pharmaceutical_plant_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PHARMACEUTICAL_PLANT);
@@ -1965,6 +1985,14 @@ if (param_extension_basic_inorganic_chemistry && param_extension_packaging_indus
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CHLO"),accept_cargo("H2__"),accept_cargo("C2H4"),accept_cargo("RFPR"),accept_cargo("MNSP"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PHARMACEUTICAL_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1991,7 +2019,6 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_packaging_indu
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [pharmaceutical_plant_industry_layout_1_tilelayout,pharmaceutical_plant_industry_layout_2_tilelayout,pharmaceutical_plant_industry_layout_3_tilelayout,pharmaceutical_plant_industry_layout_4_tilelayout,pharmaceutical_plant_industry_layout_5_tilelayout,pharmaceutical_plant_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PHARMACEUTICAL_PLANT);
@@ -2001,6 +2028,14 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_packaging_indu
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CHLO"),accept_cargo("H2__"),accept_cargo("ACID"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PHARMACEUTICAL_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2027,7 +2062,6 @@ if (param_extension_basic_inorganic_chemistry && param_extension_packaging_indus
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [pharmaceutical_plant_industry_layout_1_tilelayout,pharmaceutical_plant_industry_layout_2_tilelayout,pharmaceutical_plant_industry_layout_3_tilelayout,pharmaceutical_plant_industry_layout_4_tilelayout,pharmaceutical_plant_industry_layout_5_tilelayout,pharmaceutical_plant_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PHARMACEUTICAL_PLANT);
@@ -2037,6 +2071,14 @@ if (param_extension_basic_inorganic_chemistry && param_extension_packaging_indus
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CHLO"),accept_cargo("H2__"),accept_cargo("MNSP"),accept_cargo("ACID"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PHARMACEUTICAL_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2063,7 +2105,6 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_packaging_indu
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [pharmaceutical_plant_industry_layout_1_tilelayout,pharmaceutical_plant_industry_layout_2_tilelayout,pharmaceutical_plant_industry_layout_3_tilelayout,pharmaceutical_plant_industry_layout_4_tilelayout,pharmaceutical_plant_industry_layout_5_tilelayout,pharmaceutical_plant_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PHARMACEUTICAL_PLANT);
@@ -2073,6 +2114,14 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_packaging_indu
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CHLO"),accept_cargo("H2__"),accept_cargo("C2H4"),accept_cargo("RFPR"),accept_cargo("ACID"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PHARMACEUTICAL_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2099,7 +2148,6 @@ if (param_extension_basic_inorganic_chemistry && param_extension_packaging_indus
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [pharmaceutical_plant_industry_layout_1_tilelayout,pharmaceutical_plant_industry_layout_2_tilelayout,pharmaceutical_plant_industry_layout_3_tilelayout,pharmaceutical_plant_industry_layout_4_tilelayout,pharmaceutical_plant_industry_layout_5_tilelayout,pharmaceutical_plant_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PHARMACEUTICAL_PLANT);
@@ -2109,6 +2157,14 @@ if (param_extension_basic_inorganic_chemistry && param_extension_packaging_indus
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CHLO"),accept_cargo("H2__"),accept_cargo("C2H4"),accept_cargo("RFPR"),accept_cargo("MNSP"),accept_cargo("ACID"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PHARMACEUTICAL_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2135,7 +2191,6 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_packaging_indu
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [pharmaceutical_plant_industry_layout_1_tilelayout,pharmaceutical_plant_industry_layout_2_tilelayout,pharmaceutical_plant_industry_layout_3_tilelayout,pharmaceutical_plant_industry_layout_4_tilelayout,pharmaceutical_plant_industry_layout_5_tilelayout,pharmaceutical_plant_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PHARMACEUTICAL_PLANT);
@@ -2145,6 +2200,14 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_packaging_indu
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CHLO"),accept_cargo("H2__"),accept_cargo("O2__"),accept_cargo("NH3_"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PHARMACEUTICAL_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2171,7 +2234,6 @@ if (param_extension_basic_inorganic_chemistry && param_extension_packaging_indus
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [pharmaceutical_plant_industry_layout_1_tilelayout,pharmaceutical_plant_industry_layout_2_tilelayout,pharmaceutical_plant_industry_layout_3_tilelayout,pharmaceutical_plant_industry_layout_4_tilelayout,pharmaceutical_plant_industry_layout_5_tilelayout,pharmaceutical_plant_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PHARMACEUTICAL_PLANT);
@@ -2181,6 +2243,14 @@ if (param_extension_basic_inorganic_chemistry && param_extension_packaging_indus
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CHLO"),accept_cargo("H2__"),accept_cargo("MNSP"),accept_cargo("O2__"),accept_cargo("NH3_"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PHARMACEUTICAL_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2207,7 +2277,6 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_packaging_indu
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [pharmaceutical_plant_industry_layout_1_tilelayout,pharmaceutical_plant_industry_layout_2_tilelayout,pharmaceutical_plant_industry_layout_3_tilelayout,pharmaceutical_plant_industry_layout_4_tilelayout,pharmaceutical_plant_industry_layout_5_tilelayout,pharmaceutical_plant_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PHARMACEUTICAL_PLANT);
@@ -2217,6 +2286,14 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_packaging_indu
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CHLO"),accept_cargo("H2__"),accept_cargo("C2H4"),accept_cargo("RFPR"),accept_cargo("O2__"),accept_cargo("NH3_"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PHARMACEUTICAL_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2243,7 +2320,6 @@ if (param_extension_basic_inorganic_chemistry && param_extension_packaging_indus
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [pharmaceutical_plant_industry_layout_1_tilelayout,pharmaceutical_plant_industry_layout_2_tilelayout,pharmaceutical_plant_industry_layout_3_tilelayout,pharmaceutical_plant_industry_layout_4_tilelayout,pharmaceutical_plant_industry_layout_5_tilelayout,pharmaceutical_plant_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PHARMACEUTICAL_PLANT);
@@ -2253,6 +2329,14 @@ if (param_extension_basic_inorganic_chemistry && param_extension_packaging_indus
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CHLO"),accept_cargo("H2__"),accept_cargo("C2H4"),accept_cargo("RFPR"),accept_cargo("MNSP"),accept_cargo("O2__"),accept_cargo("NH3_"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PHARMACEUTICAL_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2279,7 +2363,6 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_packaging_indu
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [pharmaceutical_plant_industry_layout_1_tilelayout,pharmaceutical_plant_industry_layout_2_tilelayout,pharmaceutical_plant_industry_layout_3_tilelayout,pharmaceutical_plant_industry_layout_4_tilelayout,pharmaceutical_plant_industry_layout_5_tilelayout,pharmaceutical_plant_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PHARMACEUTICAL_PLANT);
@@ -2289,6 +2372,14 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_packaging_indu
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CHLO"),accept_cargo("H2__"),accept_cargo("ACID"),accept_cargo("O2__"),accept_cargo("NH3_"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PHARMACEUTICAL_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2315,7 +2406,6 @@ if (param_extension_basic_inorganic_chemistry && param_extension_packaging_indus
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [pharmaceutical_plant_industry_layout_1_tilelayout,pharmaceutical_plant_industry_layout_2_tilelayout,pharmaceutical_plant_industry_layout_3_tilelayout,pharmaceutical_plant_industry_layout_4_tilelayout,pharmaceutical_plant_industry_layout_5_tilelayout,pharmaceutical_plant_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PHARMACEUTICAL_PLANT);
@@ -2325,6 +2415,14 @@ if (param_extension_basic_inorganic_chemistry && param_extension_packaging_indus
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CHLO"),accept_cargo("H2__"),accept_cargo("MNSP"),accept_cargo("ACID"),accept_cargo("O2__"),accept_cargo("NH3_"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PHARMACEUTICAL_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2351,7 +2449,6 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_packaging_indu
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [pharmaceutical_plant_industry_layout_1_tilelayout,pharmaceutical_plant_industry_layout_2_tilelayout,pharmaceutical_plant_industry_layout_3_tilelayout,pharmaceutical_plant_industry_layout_4_tilelayout,pharmaceutical_plant_industry_layout_5_tilelayout,pharmaceutical_plant_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PHARMACEUTICAL_PLANT);
@@ -2361,6 +2458,14 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_packaging_indu
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CHLO"),accept_cargo("H2__"),accept_cargo("C2H4"),accept_cargo("RFPR"),accept_cargo("ACID"),accept_cargo("O2__"),accept_cargo("NH3_"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PHARMACEUTICAL_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2387,7 +2492,6 @@ if (param_extension_basic_inorganic_chemistry && param_extension_packaging_indus
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [pharmaceutical_plant_industry_layout_1_tilelayout,pharmaceutical_plant_industry_layout_2_tilelayout,pharmaceutical_plant_industry_layout_3_tilelayout,pharmaceutical_plant_industry_layout_4_tilelayout,pharmaceutical_plant_industry_layout_5_tilelayout,pharmaceutical_plant_industry_layout_6_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PHARMACEUTICAL_PLANT);
@@ -2397,6 +2501,14 @@ if (param_extension_basic_inorganic_chemistry && param_extension_packaging_indus
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("CHLO"),accept_cargo("H2__"),accept_cargo("C2H4"),accept_cargo("RFPR"),accept_cargo("MNSP"),accept_cargo("ACID"),accept_cargo("O2__"),accept_cargo("NH3_"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PHARMACEUTICAL_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/plastics_plant.pnml
+++ b/src/industries/plastics_plant.pnml
@@ -1552,7 +1552,6 @@ if (!param_extension_basic_inorganic_chemistry && !param_extension_painting_indu
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [plastics_plant_tilelayout_1,plastics_plant_tilelayout_2,plastics_plant_tilelayout_3,plastics_plant_tilelayout_4,plastics_plant_tilelayout_5,plastics_plant_tilelayout_6,plastics_plant_tilelayout_7];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PLASTICS_PLANT);
@@ -1562,6 +1561,14 @@ if (!param_extension_basic_inorganic_chemistry && !param_extension_painting_indu
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("OIL_"),produce_cargo("PLAS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PLASTICS_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1588,7 +1595,6 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_painting_indus
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [plastics_plant_tilelayout_1,plastics_plant_tilelayout_2,plastics_plant_tilelayout_3,plastics_plant_tilelayout_4,plastics_plant_tilelayout_5,plastics_plant_tilelayout_6,plastics_plant_tilelayout_7];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PLASTICS_PLANT);
@@ -1598,6 +1604,14 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_painting_indus
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("OIL_"),accept_cargo("CHLO"),produce_cargo("PLAS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PLASTICS_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1624,7 +1638,6 @@ if (!param_extension_basic_inorganic_chemistry && param_extension_painting_indus
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [plastics_plant_tilelayout_1,plastics_plant_tilelayout_2,plastics_plant_tilelayout_3,plastics_plant_tilelayout_4,plastics_plant_tilelayout_5,plastics_plant_tilelayout_6,plastics_plant_tilelayout_7];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PLASTICS_PLANT);
@@ -1634,6 +1647,14 @@ if (!param_extension_basic_inorganic_chemistry && param_extension_painting_indus
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("OIL_"),accept_cargo("COAT"),produce_cargo("PLAS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PLASTICS_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1660,7 +1681,6 @@ if (param_extension_basic_inorganic_chemistry && param_extension_painting_indust
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [plastics_plant_tilelayout_1,plastics_plant_tilelayout_2,plastics_plant_tilelayout_3,plastics_plant_tilelayout_4,plastics_plant_tilelayout_5,plastics_plant_tilelayout_6,plastics_plant_tilelayout_7];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PLASTICS_PLANT);
@@ -1670,6 +1690,14 @@ if (param_extension_basic_inorganic_chemistry && param_extension_painting_indust
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("OIL_"),accept_cargo("CHLO"),accept_cargo("COAT"),produce_cargo("PLAS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PLASTICS_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1696,7 +1724,6 @@ if (!param_extension_basic_inorganic_chemistry && !param_extension_painting_indu
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [plastics_plant_tilelayout_1,plastics_plant_tilelayout_2,plastics_plant_tilelayout_3,plastics_plant_tilelayout_4,plastics_plant_tilelayout_5,plastics_plant_tilelayout_6,plastics_plant_tilelayout_7];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PLASTICS_PLANT);
@@ -1706,6 +1733,14 @@ if (!param_extension_basic_inorganic_chemistry && !param_extension_painting_indu
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("C2H4"),produce_cargo("PLAS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PLASTICS_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1732,7 +1767,6 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_painting_indus
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [plastics_plant_tilelayout_1,plastics_plant_tilelayout_2,plastics_plant_tilelayout_3,plastics_plant_tilelayout_4,plastics_plant_tilelayout_5,plastics_plant_tilelayout_6,plastics_plant_tilelayout_7];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PLASTICS_PLANT);
@@ -1742,6 +1776,14 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_painting_indus
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("C2H4"),accept_cargo("CHLO"),produce_cargo("PLAS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PLASTICS_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1768,7 +1810,6 @@ if (!param_extension_basic_inorganic_chemistry && param_extension_painting_indus
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [plastics_plant_tilelayout_1,plastics_plant_tilelayout_2,plastics_plant_tilelayout_3,plastics_plant_tilelayout_4,plastics_plant_tilelayout_5,plastics_plant_tilelayout_6,plastics_plant_tilelayout_7];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PLASTICS_PLANT);
@@ -1778,6 +1819,14 @@ if (!param_extension_basic_inorganic_chemistry && param_extension_painting_indus
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("C2H4"),accept_cargo("COAT"),produce_cargo("PLAS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PLASTICS_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1804,7 +1853,6 @@ if (param_extension_basic_inorganic_chemistry && param_extension_painting_indust
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [plastics_plant_tilelayout_1,plastics_plant_tilelayout_2,plastics_plant_tilelayout_3,plastics_plant_tilelayout_4,plastics_plant_tilelayout_5,plastics_plant_tilelayout_6,plastics_plant_tilelayout_7];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PLASTICS_PLANT);
@@ -1814,6 +1862,14 @@ if (param_extension_basic_inorganic_chemistry && param_extension_painting_indust
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("C2H4"),accept_cargo("CHLO"),accept_cargo("COAT"),produce_cargo("PLAS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PLASTICS_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/port.pnml
+++ b/src/industries/port.pnml
@@ -2395,7 +2395,6 @@ if (!param_extension_aluminium && !param_extension_painting_industries && !param
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [port_tilelayout_1,port_tilelayout_2,port_tilelayout_3,port_tilelayout_4,port_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PORT);
@@ -2406,6 +2405,14 @@ if (!param_extension_aluminium && !param_extension_painting_industries && !param
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GOOD"),accept_cargo("VEHI"),produce_cargo("COAL",0),produce_cargo("OIL_",0),produce_cargo("IORE",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PORT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2430,7 +2437,6 @@ if (param_extension_aluminium && !param_extension_painting_industries && !param_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [port_tilelayout_1,port_tilelayout_2,port_tilelayout_3,port_tilelayout_4,port_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PORT);
@@ -2441,6 +2447,14 @@ if (param_extension_aluminium && !param_extension_painting_industries && !param_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GOOD"),accept_cargo("VEHI"),produce_cargo("COAL",0),produce_cargo("OIL_",0),produce_cargo("IORE",0),produce_cargo("AORE",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PORT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2465,7 +2479,6 @@ if (!param_extension_aluminium && param_extension_painting_industries && !param_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [port_tilelayout_1,port_tilelayout_2,port_tilelayout_3,port_tilelayout_4,port_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PORT);
@@ -2476,6 +2489,14 @@ if (!param_extension_aluminium && param_extension_painting_industries && !param_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GOOD"),accept_cargo("VEHI"),produce_cargo("COAL",0),produce_cargo("OIL_",0),produce_cargo("IORE",0),produce_cargo("CORE",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PORT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2500,7 +2521,6 @@ if (param_extension_aluminium && param_extension_painting_industries && !param_e
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [port_tilelayout_1,port_tilelayout_2,port_tilelayout_3,port_tilelayout_4,port_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PORT);
@@ -2511,6 +2531,14 @@ if (param_extension_aluminium && param_extension_painting_industries && !param_e
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GOOD"),accept_cargo("VEHI"),produce_cargo("COAL",0),produce_cargo("OIL_",0),produce_cargo("IORE",0),produce_cargo("AORE",0),produce_cargo("CORE",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PORT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2535,7 +2563,6 @@ if (!param_extension_aluminium && !param_extension_painting_industries && param_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [port_tilelayout_1,port_tilelayout_2,port_tilelayout_3,port_tilelayout_4,port_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PORT);
@@ -2546,6 +2573,14 @@ if (!param_extension_aluminium && !param_extension_painting_industries && param_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GOOD"),accept_cargo("VEHI"),produce_cargo("COAL",0),produce_cargo("OIL_",0),produce_cargo("IORE",0),produce_cargo("PORE",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PORT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2570,7 +2605,6 @@ if (param_extension_aluminium && !param_extension_painting_industries && param_e
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [port_tilelayout_1,port_tilelayout_2,port_tilelayout_3,port_tilelayout_4,port_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PORT);
@@ -2581,6 +2615,14 @@ if (param_extension_aluminium && !param_extension_painting_industries && param_e
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GOOD"),accept_cargo("VEHI"),produce_cargo("COAL",0),produce_cargo("OIL_",0),produce_cargo("IORE",0),produce_cargo("AORE",0),produce_cargo("PORE",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PORT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2605,7 +2647,6 @@ if (!param_extension_aluminium && param_extension_painting_industries && param_e
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [port_tilelayout_1,port_tilelayout_2,port_tilelayout_3,port_tilelayout_4,port_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PORT);
@@ -2616,6 +2657,14 @@ if (!param_extension_aluminium && param_extension_painting_industries && param_e
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GOOD"),accept_cargo("VEHI"),produce_cargo("COAL",0),produce_cargo("OIL_",0),produce_cargo("IORE",0),produce_cargo("PORE",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PORT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2640,7 +2689,6 @@ if (param_extension_aluminium && param_extension_painting_industries && param_ex
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [port_tilelayout_1,port_tilelayout_2,port_tilelayout_3,port_tilelayout_4,port_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PORT);
@@ -2651,6 +2699,14 @@ if (param_extension_aluminium && param_extension_painting_industries && param_ex
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GOOD"),accept_cargo("VEHI"),produce_cargo("COAL",0),produce_cargo("OIL_",0),produce_cargo("IORE",0),produce_cargo("AORE",0),produce_cargo("PORE",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PORT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2674,7 +2730,6 @@ if (!param_extension_aluminium && !param_extension_painting_industries && !param
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [port_tilelayout_1,port_tilelayout_2,port_tilelayout_3,port_tilelayout_4,port_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PORT);
@@ -2685,6 +2740,14 @@ if (!param_extension_aluminium && !param_extension_painting_industries && !param
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GOOD"),accept_cargo("VEHI"),produce_cargo("COAL",0),produce_cargo("OIL_",0),produce_cargo("IORE",0),produce_cargo("RUBR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PORT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2709,7 +2772,6 @@ if (param_extension_aluminium && !param_extension_painting_industries && !param_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [port_tilelayout_1,port_tilelayout_2,port_tilelayout_3,port_tilelayout_4,port_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PORT);
@@ -2720,6 +2782,14 @@ if (param_extension_aluminium && !param_extension_painting_industries && !param_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GOOD"),accept_cargo("VEHI"),produce_cargo("COAL",0),produce_cargo("OIL_",0),produce_cargo("IORE",0),produce_cargo("AORE",0),produce_cargo("RUBR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PORT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2744,7 +2814,6 @@ if (!param_extension_aluminium && param_extension_painting_industries && !param_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [port_tilelayout_1,port_tilelayout_2,port_tilelayout_3,port_tilelayout_4,port_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PORT);
@@ -2755,6 +2824,14 @@ if (!param_extension_aluminium && param_extension_painting_industries && !param_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GOOD"),accept_cargo("VEHI"),produce_cargo("COAL",0),produce_cargo("OIL_",0),produce_cargo("IORE",0),produce_cargo("CORE",0),produce_cargo("RUBR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PORT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2779,7 +2856,6 @@ if (param_extension_aluminium && param_extension_painting_industries && !param_e
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [port_tilelayout_1,port_tilelayout_2,port_tilelayout_3,port_tilelayout_4,port_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PORT);
@@ -2790,6 +2866,14 @@ if (param_extension_aluminium && param_extension_painting_industries && !param_e
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GOOD"),accept_cargo("VEHI"),produce_cargo("COAL",0),produce_cargo("OIL_",0),produce_cargo("IORE",0),produce_cargo("AORE",0),produce_cargo("CORE",0),produce_cargo("RUBR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PORT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2814,7 +2898,6 @@ if (!param_extension_aluminium && !param_extension_painting_industries && param_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [port_tilelayout_1,port_tilelayout_2,port_tilelayout_3,port_tilelayout_4,port_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PORT);
@@ -2825,6 +2908,14 @@ if (!param_extension_aluminium && !param_extension_painting_industries && param_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GOOD"),accept_cargo("VEHI"),produce_cargo("COAL",0),produce_cargo("OIL_",0),produce_cargo("IORE",0),produce_cargo("PORE",0),produce_cargo("RUBR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PORT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2849,7 +2940,6 @@ if (param_extension_aluminium && !param_extension_painting_industries && param_e
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [port_tilelayout_1,port_tilelayout_2,port_tilelayout_3,port_tilelayout_4,port_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PORT);
@@ -2860,6 +2950,14 @@ if (param_extension_aluminium && !param_extension_painting_industries && param_e
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GOOD"),accept_cargo("VEHI"),produce_cargo("COAL",0),produce_cargo("OIL_",0),produce_cargo("IORE",0),produce_cargo("AORE",0),produce_cargo("PORE",0),produce_cargo("RUBR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PORT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2884,7 +2982,6 @@ if (!param_extension_aluminium && param_extension_painting_industries && param_e
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [port_tilelayout_1,port_tilelayout_2,port_tilelayout_3,port_tilelayout_4,port_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PORT);
@@ -2895,6 +2992,14 @@ if (!param_extension_aluminium && param_extension_painting_industries && param_e
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GOOD"),accept_cargo("VEHI"),produce_cargo("COAL",0),produce_cargo("OIL_",0),produce_cargo("IORE",0),produce_cargo("PORE",0),produce_cargo("RUBR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PORT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2919,7 +3024,6 @@ if (param_extension_aluminium && param_extension_painting_industries && param_ex
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [port_tilelayout_1,port_tilelayout_2,port_tilelayout_3,port_tilelayout_4,port_tilelayout_5];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS,IND_FLAG_BUILT_ON_WATER);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_PORT);
@@ -2930,6 +3034,14 @@ if (param_extension_aluminium && param_extension_painting_industries && param_ex
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("GOOD"),accept_cargo("VEHI"),produce_cargo("COAL",0),produce_cargo("OIL_",0),produce_cargo("IORE",0),produce_cargo("AORE",0),produce_cargo("PORE",0),produce_cargo("RUBR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PORT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_BUILT_ON_WATER, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/potash_mine.pnml
+++ b/src/industries/potash_mine.pnml
@@ -626,7 +626,7 @@ if (param_extension_production_boost) {
 			life_type: IND_LIFE_TYPE_EXTRACTIVE;
 			min_cargo_distr: 1;
 			layouts: [potash_mine_industry_layout_1_tilelayout,potash_mine_industry_layout_2_tilelayout,potash_mine_industry_layout_3_tilelayout,potash_mine_industry_layout_4_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
+			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_POTASH_MINE);

--- a/src/industries/power_plant.pnml
+++ b/src/industries/power_plant.pnml
@@ -711,7 +711,6 @@ if (!param_extension_coke_sulphur && !param_extension_fruits) {
 			life_type: IND_LIFE_TYPE_BLACK_HOLE;
 			min_cargo_distr: 1;
 			layouts: [power_plant_tilelayout_1,power_plant_tilelayout_2,power_plant_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_POWER_STATION;
@@ -722,6 +721,14 @@ if (!param_extension_coke_sulphur && !param_extension_fruits) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COAL"),accept_cargo("OIL_")];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_POWER_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 
 		graphics {
@@ -746,7 +753,6 @@ if (param_extension_coke_sulphur && !param_extension_fruits) {
 			life_type: IND_LIFE_TYPE_BLACK_HOLE;
 			min_cargo_distr: 1;
 			layouts: [power_plant_tilelayout_1,power_plant_tilelayout_2,power_plant_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_POWER_STATION;
@@ -757,6 +763,14 @@ if (param_extension_coke_sulphur && !param_extension_fruits) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COAL"),accept_cargo("OIL_"),produce_cargo("SULP",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_POWER_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 
 		graphics {
@@ -781,7 +795,6 @@ if (!param_extension_coke_sulphur && param_extension_fruits) {
 			life_type: IND_LIFE_TYPE_BLACK_HOLE;
 			min_cargo_distr: 1;
 			layouts: [power_plant_tilelayout_1,power_plant_tilelayout_2,power_plant_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_POWER_STATION;
@@ -792,6 +805,14 @@ if (!param_extension_coke_sulphur && param_extension_fruits) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("BIOM"),accept_cargo("COAL"),accept_cargo("OIL_")];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_POWER_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 
 		graphics {
@@ -816,7 +837,6 @@ if (param_extension_coke_sulphur && param_extension_fruits) {
 			life_type: IND_LIFE_TYPE_BLACK_HOLE;
 			min_cargo_distr: 1;
 			layouts: [power_plant_tilelayout_1,power_plant_tilelayout_2,power_plant_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_POWER_STATION;
@@ -827,6 +847,14 @@ if (param_extension_coke_sulphur && param_extension_fruits) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("BIOM"),accept_cargo("COAL"),accept_cargo("OIL_"),produce_cargo("SULP",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_POWER_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 
 		graphics {

--- a/src/industries/printing_works.pnml
+++ b/src/industries/printing_works.pnml
@@ -298,7 +298,6 @@ if (param_extension_paper && !param_extension_packaging_industries) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [printing_works_tilelayout_1];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_PRINTING_WORKS;
@@ -308,6 +307,14 @@ if (param_extension_paper && !param_extension_packaging_industries) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PAPR"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PRINTING_WORKS));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -334,7 +341,6 @@ if (param_extension_paper && param_extension_packaging_industries) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [printing_works_tilelayout_1];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_PRINTING_WORKS;
@@ -344,6 +350,14 @@ if (param_extension_paper && param_extension_packaging_industries) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PAPR"),accept_cargo("MNSP"),produce_cargo("GOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_PRINTING_WORKS));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/recycling_depot.pnml
+++ b/src/industries/recycling_depot.pnml
@@ -284,7 +284,6 @@ if (param_extension_recycling && (param_extension_glass || param_extension_paper
 			life_type: IND_LIFE_TYPE_ORGANIC;
 			min_cargo_distr: 1;
 			layouts: [recycling_depot_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_RECYCLING_DEPOT);
@@ -294,6 +293,14 @@ if (param_extension_recycling && (param_extension_glass || param_extension_paper
 			remove_cost_multiplier: 0;
 			cargo_types: [produce_cargo("RCYC",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_RECYCLING_DEPOT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/salt_mine.pnml
+++ b/src/industries/salt_mine.pnml
@@ -720,7 +720,7 @@ if (param_extension_basic_inorganic_chemistry && !param_extension_production_boo
 			life_type: IND_LIFE_TYPE_EXTRACTIVE;
 			min_cargo_distr: 1;
 			layouts: [salt_mine_industry_layout_1_tilelayout,salt_mine_industry_layout_2_tilelayout,salt_mine_industry_layout_3_tilelayout,salt_mine_industry_layout_4_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
+			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_SALT_MINE);
@@ -755,7 +755,7 @@ if (param_extension_basic_inorganic_chemistry && param_extension_production_boos
 			life_type: IND_LIFE_TYPE_EXTRACTIVE;
 			min_cargo_distr: 1;
 			layouts: [salt_mine_industry_layout_1_tilelayout,salt_mine_industry_layout_2_tilelayout,salt_mine_industry_layout_3_tilelayout,salt_mine_industry_layout_4_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
+			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_SALT_MINE);

--- a/src/industries/sandpit.pnml
+++ b/src/industries/sandpit.pnml
@@ -1216,7 +1216,7 @@ item(FEAT_INDUSTRIES, sandpit, INDUSTRY_ID_SANDPIT) {
 		life_type: IND_LIFE_TYPE_EXTRACTIVE;
 		min_cargo_distr: 1;
 		layouts: [sandpit_layout_1_tilelayout,sandpit_layout_2_tilelayout];
-		spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
+		spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE);
 		conflicting_ind_types: [];
 		random_sound_effects: [];
 		name: string(STR_IND_SANDPIT);

--- a/src/industries/sawmill.pnml
+++ b/src/industries/sawmill.pnml
@@ -520,7 +520,6 @@ if (!param_extension_fruits) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [sawmill_tilelayout_1];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_SAWMILL;
@@ -530,6 +529,14 @@ if (!param_extension_fruits) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("WOOD"),produce_cargo("WDPR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_SAWMILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -555,7 +562,6 @@ if (param_extension_fruits) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [sawmill_tilelayout_1];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: TTD_STR_INDUSTRY_NAME_SAWMILL;
@@ -565,6 +571,14 @@ if (param_extension_fruits) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("WOOD"),produce_cargo("WDPR",0),produce_cargo("BIOM",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_SAWMILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/scrap_yard.pnml
+++ b/src/industries/scrap_yard.pnml
@@ -522,7 +522,6 @@ if (param_extension_recycling) {
 			life_type: IND_LIFE_TYPE_ORGANIC;
 			min_cargo_distr: 1;
 			layouts: [scrap_yard_tilelayout_1,scrap_yard_tilelayout_2,scrap_yard_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_SCRAP_YARD);
@@ -532,6 +531,14 @@ if (param_extension_recycling) {
 			remove_cost_multiplier: 0;
 			cargo_types: [produce_cargo("SCMT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_SCRAP_YARD));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/sheet_mill.pnml
+++ b/src/industries/sheet_mill.pnml
@@ -1473,7 +1473,6 @@ if (param_extension_metallurgy && !param_extension_aluminium && !param_extension
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [sheet_mill_tilelayout_1,sheet_mill_tilelayout_2,sheet_mill_tilelayout_3,sheet_mill_tilelayout_4,sheet_mill_tilelayout_5,sheet_mill_tilelayout_6,sheet_mill_tilelayout_7,sheet_mill_tilelayout_8];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_SHEET_MILL);
@@ -1483,6 +1482,14 @@ if (param_extension_metallurgy && !param_extension_aluminium && !param_extension
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("ACID"),accept_cargo("LYE_"),produce_cargo("STSH",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_SHEET_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1509,7 +1516,6 @@ if (param_extension_metallurgy && param_extension_aluminium && !param_extension_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [sheet_mill_tilelayout_1,sheet_mill_tilelayout_2,sheet_mill_tilelayout_3,sheet_mill_tilelayout_4,sheet_mill_tilelayout_5,sheet_mill_tilelayout_6,sheet_mill_tilelayout_7,sheet_mill_tilelayout_8];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_SHEET_MILL);
@@ -1519,6 +1525,14 @@ if (param_extension_metallurgy && param_extension_aluminium && !param_extension_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("ACID"),accept_cargo("LYE_"),accept_cargo("ALUM"),produce_cargo("STSH",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_SHEET_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1545,7 +1559,6 @@ if (param_extension_metallurgy && !param_extension_aluminium && param_extension_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [sheet_mill_tilelayout_1,sheet_mill_tilelayout_2,sheet_mill_tilelayout_3,sheet_mill_tilelayout_4,sheet_mill_tilelayout_5,sheet_mill_tilelayout_6,sheet_mill_tilelayout_7,sheet_mill_tilelayout_8];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_SHEET_MILL);
@@ -1555,6 +1568,14 @@ if (param_extension_metallurgy && !param_extension_aluminium && param_extension_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("ACID"),accept_cargo("LYE_"),produce_cargo("STSH",0),produce_cargo("SCMT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_SHEET_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1581,7 +1602,6 @@ if (param_extension_metallurgy && param_extension_aluminium && param_extension_r
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [sheet_mill_tilelayout_1,sheet_mill_tilelayout_2,sheet_mill_tilelayout_3,sheet_mill_tilelayout_4,sheet_mill_tilelayout_5,sheet_mill_tilelayout_6,sheet_mill_tilelayout_7,sheet_mill_tilelayout_8];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_SHEET_MILL);
@@ -1591,6 +1611,14 @@ if (param_extension_metallurgy && param_extension_aluminium && param_extension_r
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("ACID"),accept_cargo("LYE_"),accept_cargo("ALUM"),produce_cargo("STSH",0),produce_cargo("SCMT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_SHEET_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/soda_plant.pnml
+++ b/src/industries/soda_plant.pnml
@@ -562,7 +562,6 @@ if (param_extension_ammonia) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [soda_plant_tilelayout_1,soda_plant_tilelayout_2,soda_plant_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_SODA_PLANT);
@@ -572,6 +571,14 @@ if (param_extension_ammonia) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("NH3_"),accept_cargo("LIME"),accept_cargo("SALT"),produce_cargo("SASH",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_SODA_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/steamcracker.pnml
+++ b/src/industries/steamcracker.pnml
@@ -978,7 +978,6 @@ if (param_extension_organic_chemistry) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steamcracker_tilelayout_1, steamcracker_tilelayout_2, steamcracker_tilelayout_3, steamcracker_tilelayout_4, steamcracker_tilelayout_5, steamcracker_tilelayout_6];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_STEAMCRACKER);
@@ -988,6 +987,14 @@ if (param_extension_organic_chemistry) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("RFPR"),produce_cargo("PETR",0),produce_cargo("C2H4",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_STEAMCRACKER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/steamreformer.pnml
+++ b/src/industries/steamreformer.pnml
@@ -1232,7 +1232,6 @@ if (param_extension_organic_chemistry && !param_extension_fruits) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steamreformer_tilelayout_1, steamreformer_tilelayout_2, steamreformer_tilelayout_3, steamreformer_tilelayout_4, steamreformer_tilelayout_5, steamreformer_tilelayout_6, steamreformer_tilelayout_7];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_STEAMREFORMER);
@@ -1242,6 +1241,14 @@ if (param_extension_organic_chemistry && !param_extension_fruits) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("RFPR"),produce_cargo("H2__",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_STEAMREFORMER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1268,7 +1275,6 @@ if (param_extension_organic_chemistry && param_extension_fruits) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [steamreformer_tilelayout_1, steamreformer_tilelayout_2, steamreformer_tilelayout_3, steamreformer_tilelayout_4, steamreformer_tilelayout_5, steamreformer_tilelayout_6, steamreformer_tilelayout_7];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_STEAMREFORMER);
@@ -1278,6 +1284,14 @@ if (param_extension_organic_chemistry && param_extension_fruits) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("BIOM"),accept_cargo("RFPR"),produce_cargo("H2__",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_STEAMREFORMER));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/stockyard.pnml
+++ b/src/industries/stockyard.pnml
@@ -1278,7 +1278,6 @@ if (param_extension_food_industries && !param_extension_packaging_industries) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [stockyard_tilelayout_1];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_STOCKYARD);
@@ -1288,6 +1287,14 @@ if (param_extension_food_industries && !param_extension_packaging_industries) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("LVST"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_STOCKYARD));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1313,7 +1320,6 @@ if (param_extension_food_industries && param_extension_packaging_industries) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [stockyard_tilelayout_1];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_STOCKYARD);
@@ -1323,6 +1329,14 @@ if (param_extension_food_industries && param_extension_packaging_industries) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("LVST"),accept_cargo("MNSP"),produce_cargo("FOOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_STOCKYARD));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/synthetic_rubber_plant.pnml
+++ b/src/industries/synthetic_rubber_plant.pnml
@@ -1070,7 +1070,6 @@ if (param_extension_vehicle && !param_extension_organic_chemistry) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [synthetic_rubber_plant_tilelayout_1,synthetic_rubber_plant_tilelayout_2,synthetic_rubber_plant_tilelayout_3,synthetic_rubber_plant_tilelayout_4,synthetic_rubber_plant_tilelayout_5,synthetic_rubber_plant_tilelayout_6,synthetic_rubber_plant_tilelayout_7];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_SYNTHETIC_RUBBER_PLANT);
@@ -1080,6 +1079,14 @@ if (param_extension_vehicle && !param_extension_organic_chemistry) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("OIL_"),produce_cargo("RUBR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_SYNTHETIC_RUBBER_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1106,7 +1113,6 @@ if (param_extension_vehicle && param_extension_organic_chemistry) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [synthetic_rubber_plant_tilelayout_1,synthetic_rubber_plant_tilelayout_2,synthetic_rubber_plant_tilelayout_3,synthetic_rubber_plant_tilelayout_4,synthetic_rubber_plant_tilelayout_5,synthetic_rubber_plant_tilelayout_6,synthetic_rubber_plant_tilelayout_7];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_SYNTHETIC_RUBBER_PLANT);
@@ -1116,6 +1122,14 @@ if (param_extension_vehicle && param_extension_organic_chemistry) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("C2H4"),produce_cargo("RUBR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_SYNTHETIC_RUBBER_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/textile_mill.pnml
+++ b/src/industries/textile_mill.pnml
@@ -823,7 +823,6 @@ if (param_extension_textile_industries && !param_extension_painting_industries) 
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [textile_mill_tilelayout_1, textile_mill_tilelayout_2, textile_mill_tilelayout_3, textile_mill_tilelayout_4, textile_mill_tilelayout_5, textile_mill_tilelayout_6];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_TEXTILE_MILL);
@@ -833,6 +832,14 @@ if (param_extension_textile_industries && !param_extension_painting_industries) 
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("WOOL"),produce_cargo("TEXT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_TEXTILE_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -857,7 +864,6 @@ if (param_extension_textile_industries && param_extension_painting_industries) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [textile_mill_tilelayout_1, textile_mill_tilelayout_2, textile_mill_tilelayout_3, textile_mill_tilelayout_4, textile_mill_tilelayout_5, textile_mill_tilelayout_6];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_TEXTILE_MILL);
@@ -867,6 +873,14 @@ if (param_extension_textile_industries && param_extension_painting_industries) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("WOOL"),accept_cargo("COAT"),produce_cargo("TEXT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_TEXTILE_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/tyre_plant.pnml
+++ b/src/industries/tyre_plant.pnml
@@ -799,7 +799,6 @@ if (param_extension_vehicle && !param_extension_painting_industries) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [tyre_plant_tilelayout_1,tyre_plant_tilelayout_2,tyre_plant_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_TYRE_PLANT);
@@ -809,6 +808,14 @@ if (param_extension_vehicle && !param_extension_painting_industries) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SULP"),accept_cargo("RUBR"),produce_cargo("TYRE",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_TYRE_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -835,7 +842,6 @@ if (param_extension_vehicle && param_extension_painting_industries) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [tyre_plant_tilelayout_1,tyre_plant_tilelayout_2,tyre_plant_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_TYRE_PLANT);
@@ -845,6 +851,14 @@ if (param_extension_vehicle && param_extension_painting_industries) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("SULP"),accept_cargo("RUBR"),accept_cargo("CBLK"),produce_cargo("TYRE",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_TYRE_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/vehicle_body_plant.pnml
+++ b/src/industries/vehicle_body_plant.pnml
@@ -1054,7 +1054,6 @@ if (param_extension_vehicle && !param_extension_painting_industries && !param_ex
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_body_plant_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_BODY_PLANT);
@@ -1064,6 +1063,14 @@ if (param_extension_vehicle && !param_extension_painting_industries && !param_ex
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("ZINC"),accept_cargo("ACID"),produce_cargo("VBOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_BODY_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1090,7 +1097,6 @@ if (param_extension_vehicle && param_extension_painting_industries && !param_ext
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_body_plant_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_BODY_PLANT);
@@ -1100,6 +1106,14 @@ if (param_extension_vehicle && param_extension_painting_industries && !param_ext
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("ZINC"),accept_cargo("ACID"),accept_cargo("COAT"),produce_cargo("VBOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_BODY_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1126,7 +1140,6 @@ if (param_extension_vehicle && !param_extension_painting_industries && param_ext
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_body_plant_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_BODY_PLANT);
@@ -1136,6 +1149,14 @@ if (param_extension_vehicle && !param_extension_painting_industries && param_ext
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("ZINC"),accept_cargo("ACID"),accept_cargo("ALUM"),produce_cargo("VBOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_BODY_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1162,7 +1183,6 @@ if (param_extension_vehicle && param_extension_painting_industries && param_exte
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_body_plant_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_BODY_PLANT);
@@ -1172,6 +1192,14 @@ if (param_extension_vehicle && param_extension_painting_industries && param_exte
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("ZINC"),accept_cargo("ACID"),accept_cargo("COAT"),accept_cargo("ALUM"),produce_cargo("VBOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_BODY_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1198,7 +1226,6 @@ if (param_extension_vehicle && !param_extension_painting_industries && param_ext
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_body_plant_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_BODY_PLANT);
@@ -1208,6 +1235,14 @@ if (param_extension_vehicle && !param_extension_painting_industries && param_ext
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("ZINC"),accept_cargo("ACID"),accept_cargo("STSH"),produce_cargo("VBOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_BODY_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1234,7 +1269,6 @@ if (param_extension_vehicle && param_extension_painting_industries && param_exte
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_body_plant_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_BODY_PLANT);
@@ -1244,6 +1278,14 @@ if (param_extension_vehicle && param_extension_painting_industries && param_exte
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("ZINC"),accept_cargo("ACID"),accept_cargo("COAT"),accept_cargo("STSH"),produce_cargo("VBOD",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_BODY_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/vehicle_distributor.pnml
+++ b/src/industries/vehicle_distributor.pnml
@@ -320,7 +320,6 @@ if (!param_extension_vehicle) {
 			life_type: IND_LIFE_TYPE_BLACK_HOLE;
 			min_cargo_distr: 1;
 			layouts: [vehicle_distributor_tilelayout_1, vehicle_distributor_tilelayout_2, vehicle_distributor_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_DISTRIBUTOR);
@@ -331,6 +330,14 @@ if (!param_extension_vehicle) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("VEHI")];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_DISTRIBUTOR));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -356,7 +363,6 @@ if (param_extension_vehicle) {
 			life_type: IND_LIFE_TYPE_BLACK_HOLE;
 			min_cargo_distr: 1;
 			layouts: [vehicle_distributor_tilelayout_1, vehicle_distributor_tilelayout_2, vehicle_distributor_tilelayout_3];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_DISTRIBUTOR);
@@ -367,6 +373,14 @@ if (param_extension_vehicle) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("VEHI"),accept_cargo("TYRE"),accept_cargo("VPTS")];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_DISTRIBUTOR));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/vehicle_engine_plant.pnml
+++ b/src/industries/vehicle_engine_plant.pnml
@@ -821,7 +821,6 @@ if (param_extension_vehicle && !param_extension_aluminium && !param_extension_me
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_engine_plant_tilelayout_1,vehicle_engine_plant_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_ENGINE_PLANT);
@@ -831,6 +830,14 @@ if (param_extension_vehicle && !param_extension_aluminium && !param_extension_me
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),produce_cargo("VENG",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_ENGINE_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -857,7 +864,6 @@ if (param_extension_vehicle && param_extension_aluminium && !param_extension_met
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_engine_plant_tilelayout_1,vehicle_engine_plant_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_ENGINE_PLANT);
@@ -867,6 +873,14 @@ if (param_extension_vehicle && param_extension_aluminium && !param_extension_met
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("ALUM"),produce_cargo("VENG",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_ENGINE_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -893,7 +907,6 @@ if (param_extension_vehicle && !param_extension_aluminium && param_extension_met
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_engine_plant_tilelayout_1,vehicle_engine_plant_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_ENGINE_PLANT);
@@ -903,6 +916,14 @@ if (param_extension_vehicle && !param_extension_aluminium && param_extension_met
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("ENSP"),accept_cargo("STWR"),produce_cargo("VENG",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_ENGINE_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -929,7 +950,6 @@ if (param_extension_vehicle && param_extension_aluminium && param_extension_meta
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_engine_plant_tilelayout_1,vehicle_engine_plant_tilelayout_2];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_ENGINE_PLANT);
@@ -939,6 +959,14 @@ if (param_extension_vehicle && param_extension_aluminium && param_extension_meta
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("ALUM"),accept_cargo("ENSP"),accept_cargo("STWR"),produce_cargo("VENG",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_ENGINE_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/vehicle_factory.pnml
+++ b/src/industries/vehicle_factory.pnml
@@ -1933,7 +1933,6 @@ if (!param_extension_aluminium && !param_extension_painting_industries && !param
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_factory_tilelayout_1,vehicle_factory_tilelayout_2,vehicle_factory_tilelayout_3,vehicle_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_FACTORY);
@@ -1943,6 +1942,14 @@ if (!param_extension_aluminium && !param_extension_painting_industries && !param
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("PLAS"),produce_cargo("VEHI",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1968,7 +1975,6 @@ if (param_extension_aluminium && !param_extension_painting_industries && !param_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_factory_tilelayout_1,vehicle_factory_tilelayout_2,vehicle_factory_tilelayout_3,vehicle_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_FACTORY);
@@ -1978,6 +1984,14 @@ if (param_extension_aluminium && !param_extension_painting_industries && !param_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("PLAS"),accept_cargo("ALUM"),produce_cargo("VEHI",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2003,7 +2017,6 @@ if (!param_extension_aluminium && param_extension_painting_industries && !param_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_factory_tilelayout_1,vehicle_factory_tilelayout_2,vehicle_factory_tilelayout_3,vehicle_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_FACTORY);
@@ -2013,6 +2026,14 @@ if (!param_extension_aluminium && param_extension_painting_industries && !param_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("PLAS"),accept_cargo("COAT"),produce_cargo("VEHI",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2039,7 +2060,6 @@ if (param_extension_aluminium && param_extension_painting_industries && !param_e
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_factory_tilelayout_1,vehicle_factory_tilelayout_2,vehicle_factory_tilelayout_3,vehicle_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_FACTORY);
@@ -2049,6 +2069,14 @@ if (param_extension_aluminium && param_extension_painting_industries && !param_e
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("PLAS"),accept_cargo("COAT"),accept_cargo("ALUM"),produce_cargo("VEHI",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2075,7 +2103,6 @@ if (!param_extension_aluminium && !param_extension_painting_industries && param_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_factory_tilelayout_1,vehicle_factory_tilelayout_2,vehicle_factory_tilelayout_3,vehicle_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_FACTORY);
@@ -2085,6 +2112,14 @@ if (!param_extension_aluminium && !param_extension_painting_industries && param_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("PLAS"),accept_cargo("GLAS"),produce_cargo("VEHI",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2110,7 +2145,6 @@ if (param_extension_aluminium && !param_extension_painting_industries && param_e
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_factory_tilelayout_1,vehicle_factory_tilelayout_2,vehicle_factory_tilelayout_3,vehicle_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_FACTORY);
@@ -2120,6 +2154,14 @@ if (param_extension_aluminium && !param_extension_painting_industries && param_e
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("PLAS"),accept_cargo("ALUM"),accept_cargo("GLAS"),produce_cargo("VEHI",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2145,7 +2187,6 @@ if (!param_extension_aluminium && param_extension_painting_industries && param_e
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_factory_tilelayout_1,vehicle_factory_tilelayout_2,vehicle_factory_tilelayout_3,vehicle_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_FACTORY);
@@ -2155,6 +2196,14 @@ if (!param_extension_aluminium && param_extension_painting_industries && param_e
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("PLAS"),accept_cargo("COAT"),accept_cargo("GLAS"),produce_cargo("VEHI",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2181,7 +2230,6 @@ if (param_extension_aluminium && param_extension_painting_industries && param_ex
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_factory_tilelayout_1,vehicle_factory_tilelayout_2,vehicle_factory_tilelayout_3,vehicle_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_FACTORY);
@@ -2191,6 +2239,14 @@ if (param_extension_aluminium && param_extension_painting_industries && param_ex
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("STEL"),accept_cargo("PLAS"),accept_cargo("COAT"),accept_cargo("ALUM"),accept_cargo("GLAS"),produce_cargo("VEHI",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2217,7 +2273,6 @@ if (!param_extension_painting_industries && !param_extension_glass && param_exte
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_factory_tilelayout_1,vehicle_factory_tilelayout_2,vehicle_factory_tilelayout_3,vehicle_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_FACTORY);
@@ -2227,6 +2282,14 @@ if (!param_extension_painting_industries && !param_extension_glass && param_exte
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("STSH"),accept_cargo("STWR"),accept_cargo("ENSP"),produce_cargo("VEHI",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2253,7 +2316,6 @@ if (param_extension_painting_industries && !param_extension_glass && param_exten
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_factory_tilelayout_1,vehicle_factory_tilelayout_2,vehicle_factory_tilelayout_3,vehicle_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_FACTORY);
@@ -2263,6 +2325,14 @@ if (param_extension_painting_industries && !param_extension_glass && param_exten
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("COAT"),accept_cargo("STSH"),accept_cargo("STWR"),accept_cargo("ENSP"),produce_cargo("VEHI",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2289,7 +2359,6 @@ if (!param_extension_painting_industries && param_extension_glass && param_exten
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_factory_tilelayout_1,vehicle_factory_tilelayout_2,vehicle_factory_tilelayout_3,vehicle_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_FACTORY);
@@ -2299,6 +2368,14 @@ if (!param_extension_painting_industries && param_extension_glass && param_exten
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("GLAS"),accept_cargo("STSH"),accept_cargo("STWR"),accept_cargo("ENSP"),produce_cargo("VEHI",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2324,7 +2401,6 @@ if (param_extension_painting_industries && param_extension_glass && param_extens
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_factory_tilelayout_1,vehicle_factory_tilelayout_2,vehicle_factory_tilelayout_3,vehicle_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_FACTORY);
@@ -2334,6 +2410,14 @@ if (param_extension_painting_industries && param_extension_glass && param_extens
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("COAT"),accept_cargo("GLAS"),accept_cargo("STSH"),accept_cargo("STWR"),accept_cargo("ENSP"),produce_cargo("VEHI",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -2359,7 +2443,6 @@ if (param_extension_vehicle) {
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_factory_tilelayout_1,vehicle_factory_tilelayout_2,vehicle_factory_tilelayout_3,vehicle_factory_tilelayout_4];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_FACTORY);
@@ -2369,6 +2452,14 @@ if (param_extension_vehicle) {
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("VBOD"),accept_cargo("VENG"),accept_cargo("TYRE"),accept_cargo("VPTS"),produce_cargo("VEHI",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_FACTORY));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/vehicle_parts_plant.pnml
+++ b/src/industries/vehicle_parts_plant.pnml
@@ -919,7 +919,6 @@ if (param_extension_vehicle && !param_extension_textile_industries && !param_ext
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_parts_plant_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_PARTS_PLANT);
@@ -929,6 +928,14 @@ if (param_extension_vehicle && !param_extension_textile_industries && !param_ext
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("STEL"),produce_cargo("VPTS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_PARTS_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -955,7 +962,6 @@ if (param_extension_vehicle && param_extension_textile_industries && !param_exte
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_parts_plant_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_PARTS_PLANT);
@@ -965,6 +971,14 @@ if (param_extension_vehicle && param_extension_textile_industries && !param_exte
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("TEXT"),accept_cargo("STEL"),produce_cargo("VPTS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_PARTS_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -991,7 +1005,6 @@ if (param_extension_vehicle && !param_extension_textile_industries && param_exte
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_parts_plant_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_PARTS_PLANT);
@@ -1001,6 +1014,14 @@ if (param_extension_vehicle && !param_extension_textile_industries && param_exte
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("GLAS"),accept_cargo("STEL"),produce_cargo("VPTS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_PARTS_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1027,7 +1048,6 @@ if (param_extension_vehicle && param_extension_textile_industries && param_exten
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_parts_plant_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_PARTS_PLANT);
@@ -1037,6 +1057,14 @@ if (param_extension_vehicle && param_extension_textile_industries && param_exten
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("TEXT"),accept_cargo("GLAS"),accept_cargo("STEL"),produce_cargo("VPTS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_PARTS_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1063,7 +1091,6 @@ if (param_extension_vehicle && !param_extension_textile_industries && !param_ext
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_parts_plant_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_PARTS_PLANT);
@@ -1073,6 +1100,14 @@ if (param_extension_vehicle && !param_extension_textile_industries && !param_ext
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("STWR"),accept_cargo("STEL"),produce_cargo("VPTS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_PARTS_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1099,7 +1134,6 @@ if (param_extension_vehicle && param_extension_textile_industries && !param_exte
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_parts_plant_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_PARTS_PLANT);
@@ -1109,6 +1143,14 @@ if (param_extension_vehicle && param_extension_textile_industries && !param_exte
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("TEXT"),accept_cargo("STWR"),accept_cargo("STEL"),produce_cargo("VPTS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_PARTS_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1135,7 +1177,6 @@ if (param_extension_vehicle && !param_extension_textile_industries && param_exte
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_parts_plant_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_PARTS_PLANT);
@@ -1145,6 +1186,14 @@ if (param_extension_vehicle && !param_extension_textile_industries && param_exte
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("GLAS"),accept_cargo("STWR"),accept_cargo("STEL"),produce_cargo("VPTS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_PARTS_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1171,7 +1220,6 @@ if (param_extension_vehicle && param_extension_textile_industries && param_exten
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [vehicle_parts_plant_tilelayout];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_VEHICLE_PARTS_PLANT);
@@ -1181,6 +1229,14 @@ if (param_extension_vehicle && param_extension_textile_industries && param_exten
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("PLAS"),accept_cargo("TEXT"),accept_cargo("GLAS"),accept_cargo("STWR"),accept_cargo("STEL"),produce_cargo("VPTS",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_VEHICLE_PARTS_PLANT));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {

--- a/src/industries/wire_mill.pnml
+++ b/src/industries/wire_mill.pnml
@@ -1607,7 +1607,6 @@ if (param_extension_metallurgy && !param_extension_aluminium && !param_extension
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [wire_mill_tilelayout_1,wire_mill_tilelayout_2,wire_mill_tilelayout_3,wire_mill_tilelayout_4,wire_mill_tilelayout_5,wire_mill_tilelayout_6,wire_mill_tilelayout_7,wire_mill_tilelayout_8];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_WIRE_MILL);
@@ -1617,6 +1616,14 @@ if (param_extension_metallurgy && !param_extension_aluminium && !param_extension
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COPR"),accept_cargo("ACID"),accept_cargo("LYE_"),produce_cargo("STWR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_WIRE_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1643,7 +1650,6 @@ if (param_extension_metallurgy && param_extension_aluminium && !param_extension_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [wire_mill_tilelayout_1,wire_mill_tilelayout_2,wire_mill_tilelayout_3,wire_mill_tilelayout_4,wire_mill_tilelayout_5,wire_mill_tilelayout_6,wire_mill_tilelayout_7,wire_mill_tilelayout_8];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_WIRE_MILL);
@@ -1653,6 +1659,14 @@ if (param_extension_metallurgy && param_extension_aluminium && !param_extension_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COPR"),accept_cargo("ACID"),accept_cargo("LYE_"),accept_cargo("ALUM"),produce_cargo("STWR",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_WIRE_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1679,7 +1693,6 @@ if (param_extension_metallurgy && !param_extension_aluminium && param_extension_
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [wire_mill_tilelayout_1,wire_mill_tilelayout_2,wire_mill_tilelayout_3,wire_mill_tilelayout_4,wire_mill_tilelayout_5,wire_mill_tilelayout_6,wire_mill_tilelayout_7,wire_mill_tilelayout_8];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_WIRE_MILL);
@@ -1689,6 +1702,14 @@ if (param_extension_metallurgy && !param_extension_aluminium && param_extension_
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COPR"),accept_cargo("ACID"),accept_cargo("LYE_"),produce_cargo("STWR",0),produce_cargo("SCMT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_WIRE_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {
@@ -1715,7 +1736,6 @@ if (param_extension_metallurgy && param_extension_aluminium && param_extension_r
 			life_type: IND_LIFE_TYPE_PROCESSING;
 			min_cargo_distr: 1;
 			layouts: [wire_mill_tilelayout_1,wire_mill_tilelayout_2,wire_mill_tilelayout_3,wire_mill_tilelayout_4,wire_mill_tilelayout_5,wire_mill_tilelayout_6,wire_mill_tilelayout_7,wire_mill_tilelayout_8];
-			spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS);
 			conflicting_ind_types: [];
 			random_sound_effects: [];
 			name: string(STR_IND_WIRE_MILL);
@@ -1725,6 +1745,14 @@ if (param_extension_metallurgy && param_extension_aluminium && param_extension_r
 			remove_cost_multiplier: 0;
 			cargo_types: [accept_cargo("COPR"),accept_cargo("ACID"),accept_cargo("LYE_"),accept_cargo("ALUM"),produce_cargo("STWR",0),produce_cargo("SCMT",0)];
 			nearby_station_name: string(STR_STATION, string(STR_TOWN),string(STR_STATION_WIRE_MILL));
+		}
+		if (param_forbid_last_industry_closure)
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS); }
+		}
+		else
+		{
+			property { spec_flags: bitmask(IND_FLAG_LONG_CARGO_TYPE_LISTS, IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE); }
 		}
 			
 		graphics {


### PR DESCRIPTION
Primary industries did not close correctly when they were the last instance on the map. This is now fixed. In addition, it can now be configured whether or not the last instance of a secondary industry can be randomly removed or not.

Fixes #80 